### PR TITLE
Fix example namespace typo

### DIFF
--- a/examples/ControllerServiceRepository1/SomeController.php
+++ b/examples/ControllerServiceRepository1/SomeController.php
@@ -1,8 +1,8 @@
 <?php 
 
-namespace exmaples\MyNamespace\Controllers;
+namespace examples\MyNamespace\Controllers;
 
-use exmaples\MyNamespace\Service\SomeService;
+use examples\MyNamespace\Service\SomeService;
 
 class SomeController
 {

--- a/examples/ControllerServiceRepository1/SomeRepository.php
+++ b/examples/ControllerServiceRepository1/SomeRepository.php
@@ -1,7 +1,7 @@
 <?php
 
-namespace exmaples\MyNamespace\Repository;
+namespace examples\MyNamespace\Repository;
 
-use exmaples\MyNamespace\Controllers\SomeController;
+use examples\MyNamespace\Controllers\SomeController;
 
 class SomeRepository { }

--- a/examples/ControllerServiceRepository1/SomeService.php
+++ b/examples/ControllerServiceRepository1/SomeService.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace exmaples\MyNamespace\Service;
+namespace examples\MyNamespace\Service;
 
-use exmaples\MyNamespace\Repository\SomeRepository;
+use examples\MyNamespace\Repository\SomeRepository;
 
 class SomeService
 {

--- a/examples/ModelController1/SomeController.php
+++ b/examples/ModelController1/SomeController.php
@@ -1,6 +1,6 @@
 <?php 
 
-namespace exmaples\MyNamespace\Controllers;
+namespace examples\MyNamespace\Controllers;
 
 class SomeController
 {

--- a/examples/ModelController1/SomeModel.php
+++ b/examples/ModelController1/SomeModel.php
@@ -1,6 +1,6 @@
 <?php 
 
-namespace exmaples\MyNamespace\Models;
+namespace examples\MyNamespace\Models;
 
 class SomeModel
 {

--- a/examples/ModelController2/SomeController.php
+++ b/examples/ModelController2/SomeController.php
@@ -1,8 +1,8 @@
 <?php 
 
-namespace exmaples\MyNamespace\Controllers;
+namespace examples\MyNamespace\Controllers;
 
-use exmaples\MyNamespace\Models\SomeModel;
+use examples\MyNamespace\Models\SomeModel;
 
 class SomeController
 {

--- a/examples/ModelController2/SomeModel.php
+++ b/examples/ModelController2/SomeModel.php
@@ -1,6 +1,6 @@
 <?php 
 
-namespace exmaples\MyNamespace\Models;
+namespace examples\MyNamespace\Models;
 
 class SomeModel
 {


### PR DESCRIPTION
The ex of mample is not amused.
