### PR TITLE
composer-dependency-analyser: no unused dep ignore, rather scan the file with usage

### DIFF
--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -6,5 +6,5 @@ use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
 $config = new Configuration();
 
 return $config
-    ->ignoreErrorsOnPackage('composer/xdebug-handler', [ErrorType::UNUSED_DEPENDENCY]) // needed for e2e tests, no direct usage in code
+    ->addPathToScan(__DIR__ . '/deptrac.php', isDev: false)
     ->ignoreErrorsOnPath(__DIR__ . '/tests', [ErrorType::UNKNOWN_CLASS]); // keep ability to test invalid symbols


### PR DESCRIPTION
I was mistaken in the initial setup.