### PR TITLE
add keyword to mark Deptrac as a dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,9 @@
 {
     "name": "qossmic/deptrac",
     "description": "Deptrac is a static code analysis tool that helps to enforce rules for dependencies between software layers.",
+    "keywords": [
+        "static analysis"
+    ],
     "license": "MIT",
     "require": {
         "php": "^8.1",


### PR DESCRIPTION
Adding the `static analysis` keywords makes Composer prompt the user to suggest re-running `composer require` with `--dev` automatically if the option was forgotten by the user (see https://getcomposer.org/doc/04-schema.md#keywords).