### PR TITLE
Add support for Symfony 7 without dropping PHP8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,14 +27,14 @@
         "phpstan/phpdoc-parser": "^2.0",
         "psr/container": "^2.0",
         "psr/event-dispatcher": "^1.0",
-        "symfony/config": "^6.4",
-        "symfony/console": "^6.4",
-        "symfony/dependency-injection": "^6.4",
-        "symfony/event-dispatcher": "^6.4",
+        "symfony/config": "^6.4|^7.0",
+        "symfony/console": "^6.4|^7.0",
+        "symfony/dependency-injection": "^6.4|^7.0",
+        "symfony/event-dispatcher": "^6.4|^7.0",
         "symfony/event-dispatcher-contracts": "^3.4",
-        "symfony/filesystem": "^6.4",
-        "symfony/finder": "^6.4",
-        "symfony/yaml": "^6.4"
+        "symfony/filesystem": "^6.4|^7.0",
+        "symfony/finder": "^6.4|^7.0",
+        "symfony/yaml": "^6.4|^7.0"
     },
     "require-dev": {
         "ext-libxml": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2aeef407e1a45ca6c1915eada2cd327",
+    "content-hash": "840e6224b72dcf0b4132a6c0d0d9d4ab",
     "packages": [
         {
             "name": "composer/pcre",
@@ -667,16 +667,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v6.4.14",
+            "version": "v6.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "4e55e7e4ffddd343671ea972216d4509f46c22ef"
+                "reference": "80e2cf005cf17138c97193be0434cdcfd1b2212e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/4e55e7e4ffddd343671ea972216d4509f46c22ef",
-                "reference": "4e55e7e4ffddd343671ea972216d4509f46c22ef",
+                "url": "https://api.github.com/repos/symfony/config/zipball/80e2cf005cf17138c97193be0434cdcfd1b2212e",
+                "reference": "80e2cf005cf17138c97193be0434cdcfd1b2212e",
                 "shasum": ""
             },
             "require": {
@@ -722,7 +722,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v6.4.14"
+                "source": "https://github.com/symfony/config/tree/v6.4.24"
             },
             "funding": [
                 {
@@ -734,24 +734,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-04T11:33:53+00:00"
+            "time": "2025-07-26T13:50:30+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.15",
+            "version": "v6.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "f1fc6f47283e27336e7cebb9e8946c8de7bff9bd"
+                "reference": "59266a5bf6a596e3e0844fd95e6ad7ea3c1d3350"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/f1fc6f47283e27336e7cebb9e8946c8de7bff9bd",
-                "reference": "f1fc6f47283e27336e7cebb9e8946c8de7bff9bd",
+                "url": "https://api.github.com/repos/symfony/console/zipball/59266a5bf6a596e3e0844fd95e6ad7ea3c1d3350",
+                "reference": "59266a5bf6a596e3e0844fd95e6ad7ea3c1d3350",
                 "shasum": ""
             },
             "require": {
@@ -816,7 +820,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.15"
+                "source": "https://github.com/symfony/console/tree/v6.4.24"
             },
             "funding": [
                 {
@@ -828,11 +832,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-06T14:19:14+00:00"
+            "time": "2025-07-30T10:38:54+00:00"
         },
         {
             "name": "symfony/dependency-injection",
@@ -984,16 +992,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v6.4.13",
+            "version": "v6.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "0ffc48080ab3e9132ea74ef4e09d8dcf26bf897e"
+                "reference": "307a09d8d7228d14a05e5e05b95fffdacab032b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/0ffc48080ab3e9132ea74ef4e09d8dcf26bf897e",
-                "reference": "0ffc48080ab3e9132ea74ef4e09d8dcf26bf897e",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/307a09d8d7228d14a05e5e05b95fffdacab032b2",
+                "reference": "307a09d8d7228d14a05e5e05b95fffdacab032b2",
                 "shasum": ""
             },
             "require": {
@@ -1044,7 +1052,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v6.4.13"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v6.4.24"
             },
             "funding": [
                 {
@@ -1056,11 +1064,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:18:03+00:00"
+            "time": "2025-07-10T08:14:14+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -1140,16 +1152,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.4.13",
+            "version": "v6.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "4856c9cf585d5a0313d8d35afd681a526f038dd3"
+                "reference": "75ae2edb7cdcc0c53766c30b0a2512b8df574bd8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/4856c9cf585d5a0313d8d35afd681a526f038dd3",
-                "reference": "4856c9cf585d5a0313d8d35afd681a526f038dd3",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/75ae2edb7cdcc0c53766c30b0a2512b8df574bd8",
+                "reference": "75ae2edb7cdcc0c53766c30b0a2512b8df574bd8",
                 "shasum": ""
             },
             "require": {
@@ -1186,7 +1198,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.4.13"
+                "source": "https://github.com/symfony/filesystem/tree/v6.4.24"
             },
             "funding": [
                 {
@@ -1198,24 +1210,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-25T15:07:50+00:00"
+            "time": "2025-07-10T08:14:14+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v6.4.13",
+            "version": "v6.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "daea9eca0b08d0ed1dc9ab702a46128fd1be4958"
+                "reference": "73089124388c8510efb8d2d1689285d285937b08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/daea9eca0b08d0ed1dc9ab702a46128fd1be4958",
-                "reference": "daea9eca0b08d0ed1dc9ab702a46128fd1be4958",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/73089124388c8510efb8d2d1689285d285937b08",
+                "reference": "73089124388c8510efb8d2d1689285d285937b08",
                 "shasum": ""
             },
             "require": {
@@ -1250,7 +1266,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v6.4.13"
+                "source": "https://github.com/symfony/finder/tree/v6.4.24"
             },
             "funding": [
                 {
@@ -1262,11 +1278,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-01T08:30:56+00:00"
+            "time": "2025-07-15T12:02:45+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1834,16 +1854,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v6.4.13",
+            "version": "v6.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "e99b4e94d124b29ee4cf3140e1b537d2dad8cec9"
+                "reference": "742a8efc94027624b36b10ba58e23d402f961f51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/e99b4e94d124b29ee4cf3140e1b537d2dad8cec9",
-                "reference": "e99b4e94d124b29ee4cf3140e1b537d2dad8cec9",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/742a8efc94027624b36b10ba58e23d402f961f51",
+                "reference": "742a8efc94027624b36b10ba58e23d402f961f51",
                 "shasum": ""
             },
             "require": {
@@ -1886,7 +1906,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.4.13"
+                "source": "https://github.com/symfony/yaml/tree/v6.4.24"
             },
             "funding": [
                 {
@@ -1898,11 +1918,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:18:03+00:00"
+            "time": "2025-07-10T08:14:14+00:00"
         }
     ],
     "packages-dev": [
@@ -2596,7 +2620,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/src/Supportive/Console/Command/AnalyseCommand.php
+++ b/src/Supportive/Console/Command/AnalyseCommand.php
@@ -13,6 +13,7 @@ use Deptrac\Deptrac\Supportive\Console\Symfony\Style;
 use Deptrac\Deptrac\Supportive\Console\Symfony\SymfonyOutput;
 use Deptrac\Deptrac\Supportive\OutputFormatter\FormatterProvider;
 use Deptrac\Deptrac\Supportive\Time\Stopwatch;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -20,14 +21,15 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[AsCommand(
+    name: 'analyse|analyze',
+    description: 'Analyses your project using the provided depfile',
+)]
 class AnalyseCommand extends Command
 {
     final public const OPTION_REPORT_UNCOVERED = 'report-uncovered';
     final public const OPTION_FAIL_ON_UNCOVERED = 'fail-on-uncovered';
     final public const OPTION_REPORT_SKIPPED = 'report-skipped';
-
-    public static $defaultName = 'analyse|analyze';
-    public static $defaultDescription = 'Analyses your project using the provided depfile';
 
     public function __construct(
         private readonly AnalyseRunner $runner,

--- a/src/Supportive/Console/Command/ChangedFilesCommand.php
+++ b/src/Supportive/Console/Command/ChangedFilesCommand.php
@@ -6,6 +6,7 @@ namespace Deptrac\Deptrac\Supportive\Console\Command;
 
 use Deptrac\Deptrac\Supportive\Console\Symfony\Style;
 use Deptrac\Deptrac\Supportive\Console\Symfony\SymfonyOutput;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -13,11 +14,12 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(
+    name: 'changed-files',
+    description: 'Lists layers corresponding to the changed files',
+)]
 class ChangedFilesCommand extends Command
 {
-    public static $defaultName = 'changed-files';
-    public static $defaultDescription = 'Lists layers corresponding to the changed files';
-
     public function __construct(
         private readonly ChangedFilesRunner $runner,
     ) {

--- a/src/Supportive/Console/Command/DebugDependenciesCommand.php
+++ b/src/Supportive/Console/Command/DebugDependenciesCommand.php
@@ -6,17 +6,19 @@ namespace Deptrac\Deptrac\Supportive\Console\Command;
 
 use Deptrac\Deptrac\Supportive\Console\Symfony\Style;
 use Deptrac\Deptrac\Supportive\Console\Symfony\SymfonyOutput;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(
+    name: 'debug:dependencies',
+    description: 'List layer dependencies',
+)]
 class DebugDependenciesCommand extends Command
 {
-    public static $defaultName = 'debug:dependencies';
-    public static $defaultDescription = 'List layer dependencies';
-
     public function __construct(private readonly DebugDependenciesRunner $runner)
     {
         parent::__construct();

--- a/src/Supportive/Console/Command/DebugLayerCommand.php
+++ b/src/Supportive/Console/Command/DebugLayerCommand.php
@@ -6,17 +6,19 @@ namespace Deptrac\Deptrac\Supportive\Console\Command;
 
 use Deptrac\Deptrac\Supportive\Console\Symfony\Style;
 use Deptrac\Deptrac\Supportive\Console\Symfony\SymfonyOutput;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(
+    name: 'debug:layer',
+    description: 'Checks which tokens belong to the provided layer',
+)]
 class DebugLayerCommand extends Command
 {
-    public static $defaultName = 'debug:layer';
-    public static $defaultDescription = 'Checks which tokens belong to the provided layer';
-
     public function __construct(private readonly DebugLayerRunner $runner)
     {
         parent::__construct();

--- a/src/Supportive/Console/Command/DebugTokenCommand.php
+++ b/src/Supportive/Console/Command/DebugTokenCommand.php
@@ -7,17 +7,19 @@ namespace Deptrac\Deptrac\Supportive\Console\Command;
 use Deptrac\Deptrac\Core\Analyser\TokenType;
 use Deptrac\Deptrac\Supportive\Console\Symfony\Style;
 use Deptrac\Deptrac\Supportive\Console\Symfony\SymfonyOutput;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(
+    name: 'debug:token|debug:class-like',
+    description: 'Checks which layers the provided token belongs to',
+)]
 class DebugTokenCommand extends Command
 {
-    public static $defaultName = 'debug:token|debug:class-like';
-    public static $defaultDescription = 'Checks which layers the provided token belongs to';
-
     public function __construct(private readonly DebugTokenRunner $runner)
     {
         parent::__construct();

--- a/src/Supportive/Console/Command/DebugUnassignedCommand.php
+++ b/src/Supportive/Console/Command/DebugUnassignedCommand.php
@@ -6,15 +6,18 @@ namespace Deptrac\Deptrac\Supportive\Console\Command;
 
 use Deptrac\Deptrac\Supportive\Console\Symfony\Style;
 use Deptrac\Deptrac\Supportive\Console\Symfony\SymfonyOutput;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(
+    name: 'debug:unassigned',
+    description: 'Lists tokens that are not assigned to any layer',
+)]
 class DebugUnassignedCommand extends Command
 {
-    public static $defaultName = 'debug:unassigned';
-    public static $defaultDescription = 'Lists tokens that are not assigned to any layer';
     public const EXIT_WITH_UNASSIGNED_TOKENS = 2;
 
     public function __construct(private readonly DebugUnassignedRunner $runner)

--- a/src/Supportive/Console/Command/DebugUnusedCommand.php
+++ b/src/Supportive/Console/Command/DebugUnusedCommand.php
@@ -6,17 +6,19 @@ namespace Deptrac\Deptrac\Supportive\Console\Command;
 
 use Deptrac\Deptrac\Supportive\Console\Symfony\Style;
 use Deptrac\Deptrac\Supportive\Console\Symfony\SymfonyOutput;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(
+    name: 'debug:unused',
+    description: 'Lists unused (or barely used) layer dependencies',
+)]
 class DebugUnusedCommand extends Command
 {
-    public static $defaultName = 'debug:unused';
-    public static $defaultDescription = 'Lists unused (or barely used) layer dependencies';
-
     public function __construct(private readonly DebugUnusedRunner $runner)
     {
         parent::__construct();

--- a/src/Supportive/Console/Command/InitCommand.php
+++ b/src/Supportive/Console/Command/InitCommand.php
@@ -9,17 +9,19 @@ use Deptrac\Deptrac\Supportive\File\Exception\FileAlreadyExistsException;
 use Deptrac\Deptrac\Supportive\File\Exception\FileNotExistsException;
 use Deptrac\Deptrac\Supportive\File\Exception\FileNotWritableException;
 use Deptrac\Deptrac\Supportive\File\Exception\IOException;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function sprintf;
 
+#[AsCommand(
+    name: 'init',
+    description: 'Creates a depfile template',
+)]
 class InitCommand extends Command
 {
-    public static $defaultName = 'init';
-    public static $defaultDescription = 'Creates a depfile template';
-
     public function __construct(private readonly ConfigurationDumper $dumper)
     {
         parent::__construct();


### PR DESCRIPTION
Alternative PR for https://github.com/deptrac/deptrac/pull/1489 without dropping PHP 8.1 support

Looks like this does not use Symfony 7 in the pipeline because of ``composer.lock``. 
Shouldn't we remove ``composer.lock`` from the repo? It's only used while working on the project, but now we are always working with fixed versions, see https://getcomposer.org/doc/02-libraries.md#lock-file.
This means we can't test version restrictions like ``^6.0|^7.0``, because during all pipeline checks the same version is used.
