### PR TITLE
Add depender layer to error message so it's easier to spot what's going on.

### DIFF
--- a/src/DefaultBehavior/OutputFormatter/TableOutputFormatter.php
+++ b/src/DefaultBehavior/OutputFormatter/TableOutputFormatter.php
@@ -110,7 +110,12 @@ final class TableOutputFormatter implements OutputFormatterInterface
             $dependency->getDepender()->toString(),
             $dependency->getDependent()->toString(),
         );
-        $message .= sprintf("\n%s (%s)", $rule->ruleDescription(), $rule->getDependentLayer());
+        $message .= sprintf(
+            "\n%s (<info>%s</info> -> <info>%s</info>)",
+            $rule->ruleDescription(),
+            $rule->getDependerLayer(),
+            $rule->getDependentLayer(),
+        );
 
         if (count($dependency->serialize()) > 1) {
             $message .= "\n".$this->formatMultilinePath($dependency);

--- a/tests/Supportive/OutputFormatter/TableOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/TableOutputFormatterTest.php
@@ -85,7 +85,7 @@ class TableOutputFormatterTest extends TestCase
   Reason      LayerA                            
  ----------- ---------------------------------- 
   DummyRule   ClassA must not depend on ClassB  
-              Why? Because! (LayerB)            
+              Why? Because! (LayerA -> LayerB)            
               ClassInheritD::6 ->               
               ClassInheritC::5 ->               
               ClassInheritB::4 ->               

--- a/tests/Supportive/OutputFormatter/TableOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/TableOutputFormatterTest.php
@@ -124,7 +124,7 @@ class TableOutputFormatterTest extends TestCase
   Reason      LayerA                                  
  ----------- ---------------------------------------- 
   DummyRule   OriginalA must not depend on OriginalB  
-              Why? Because! (LayerB)                  
+              Why? Because! (LayerA -> LayerB)                  
               originalA.php:12                        
  ----------- ---------------------------------------- 
 
@@ -175,7 +175,7 @@ class TableOutputFormatterTest extends TestCase
             ' --------- ------------------------------------------------- 
   Reason    LayerA                                           
  --------- ------------------------------------------------- 
-  Skipped   OriginalA must not depend on OriginalB (LayerB)  
+  Skipped   OriginalA must not depend on OriginalB (LayerA -> LayerB)  
             originalA.php:12                                 
  --------- ------------------------------------------------- 
 


### PR DESCRIPTION
# Currently

>  DependsOnDisallowedLayer   App\One\Class must not depend on App\Two\Class
>                               You are depending on token that is a part of a layer that you are not allowed to depend on. (Two)
>                               /var/www/html/src/One/Class.php:1


> [!NOTE]
> Easily readable that a class cannot depend on layer Two, but... what layer does that class belong to?



# Proposed

> DependsOnDisallowedLayer   App\One\Class must not depend on App\Two\Class
>                              You are depending on token that is a part of a layer that you are not allowed to depend on. (One -> Two)
>                              /var/www/html/src/One/Class.php:1

> [!NOTE]
> Easily readable that layer One cannot depend on layer Two.