### PR TITLE
Fix PHPDoc with integer range (for example int<0, max>

### DIFF
--- a/src/Core/Ast/Parser/NikicTypeResolver.php
+++ b/src/Core/Ast/Parser/NikicTypeResolver.php
@@ -136,7 +136,17 @@ class NikicTypeResolver implements TypeResolverInterface
      */
     private function resolveGeneric(GenericTypeNode $type, TypeScope $typeScope, array $templateTypes): array
     {
-        $preType = 'list' === $type->type->name
+        /** Generic int (e.g. int<0, max>) can never contain resolvable generic type, so only resolve the `int` */
+        if ('int' === $type->type->name) {
+            return $this->resolvePHPStanDocParserType(
+                $type->type,
+                $typeScope,
+                $templateTypes
+            );
+        }
+
+        /** Does the identifier of generic (e.g. list in list<Class>) need resolving? */
+        $preType = in_array($type->type->name, ['list', 'non-empty-list'], true)
             ? []
             : $this->resolvePHPStanDocParserType(
                 $type->type,

--- a/tests/Core/Ast/Parser/Fixtures/AnnotationDependency.php
+++ b/tests/Core/Ast/Parser/Fixtures/AnnotationDependency.php
@@ -62,4 +62,12 @@ final class AnnotationDependencyChild
     {
 
     }
+
+    /**
+     * @param int<0, max> $rangeParameter
+     */
+    public function intRangeTest($rangeParameter)
+    {
+
+    }
 }


### PR DESCRIPTION
Closes: #1502 

It wrongly resolves the `max` into a class. Incidentally, fix the same issue with `non-empty-list`, which was not supported before, only `list`.