### PR TITLE
Expand the scope of ignored PHP-Doc tags

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -37,7 +37,7 @@ parameters:
 			path: src/Core/Analyser/UnassignedTokenAnalyser.php
 
 		-
-			message: '#^Property Deptrac\\Deptrac\\DefaultBehavior\\Ast\\Parser\\Helpers\\ReferenceBuilder\:\:\$tokenTemplates \(list\<string\>\) does not accept array\<int\<0, max\>, string\>\.$#'
+			message: '#^Property Deptrac\\Deptrac\\DefaultBehavior\\Ast\\Parser\\Helpers\\ReferenceBuilder\:\:\$tokenTemplateLikes \(list\<string\>\) does not accept array\<int\<0, max\>, string\>\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: src/DefaultBehavior/Ast/Parser/Helpers/ReferenceBuilder.php

--- a/src/Contract/Ast/AstMap/ReferenceBuilderInterface.php
+++ b/src/Contract/Ast/AstMap/ReferenceBuilderInterface.php
@@ -16,7 +16,7 @@ interface ReferenceBuilderInterface
     /**
      * @return list<string>
      */
-    public function getTokenTemplates(): array;
+    public function getTokenTemplateLikes(): array;
 
     public function dependency(TokenInterface $token, int $occursAtLine, DependencyType $type): static;
 

--- a/src/DefaultBehavior/Ast/DocParsingHelper.php
+++ b/src/DefaultBehavior/Ast/DocParsingHelper.php
@@ -37,12 +37,12 @@ class DocParsingHelper
     }
 
     /**
-     * @param list<string> $tokenTemplates
+     * @param list<string> $tokenTemplateLikes
      *
      * @return ?array{PhpDocNode, list<string>}
      */
-    public static function resolvePHPDocWithNativeScope(Node $node, Lexer $lexer, PhpDocParser $docParser, array $tokenTemplates): ?array
-    {
+    public static function resolvePHPDocWithNativeScope(Node $node, Lexer $lexer, PhpDocParser $docParser, array $tokenTemplateLikes,
+    ): ?array {
         $docComment = $node->getDocComment();
         if (!$docComment instanceof Doc) {
             return null;
@@ -53,11 +53,21 @@ class DocParsingHelper
         $templateTypes = array_values(array_merge(
             array_map(
                 static fn (TemplateTagValueNode $node): string => $node->name,
-                $docNode->getTemplateTagValues()
+                self::getTagsIntroducingIgnoredNames($docNode)
             ),
-            $tokenTemplates
+            $tokenTemplateLikes
         ));
 
         return [$docNode, $templateTypes];
+    }
+
+    /**
+     * These tags produce "names" or tokens that should be ignored by Deptrac.
+     */
+    private static function getTagsIntroducingIgnoredNames(PhpDocNode $docNode): array
+    {
+        return $docNode->getTemplateTagValues()
+               + $docNode->getTemplateTagValues('@template-covariant')
+               + $docNode->getTypeAliasTagValues() + $docNode->getTypeAliasImportTagValues();
     }
 }

--- a/src/DefaultBehavior/Ast/DocParsingHelper.php
+++ b/src/DefaultBehavior/Ast/DocParsingHelper.php
@@ -11,6 +11,8 @@ use PHPStan\Analyser\MutatingScope;
 use PHPStan\PhpDoc\ResolvedPhpDocBlock;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\TemplateTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\TypeAliasImportTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\TypeAliasTagValueNode;
 use PHPStan\PhpDocParser\Lexer\Lexer;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use PHPStan\PhpDocParser\Parser\TokenIterator;
@@ -50,24 +52,24 @@ class DocParsingHelper
 
         $tokens = new TokenIterator($lexer->tokenize($docComment->getText()));
         $docNode = $docParser->parse($tokens);
-        $templateTypes = array_values(array_merge(
-            array_map(
-                static fn (TemplateTagValueNode $node): string => $node->name,
-                self::getTagsIntroducingIgnoredNames($docNode)
-            ),
-            $tokenTemplateLikes
-        ));
+        $templateTypes = array_merge(self::getTagsIntroducingIgnoredNames($docNode), $tokenTemplateLikes);
 
         return [$docNode, $templateTypes];
     }
 
     /**
      * These tags produce "names" or tokens that should be ignored by Deptrac.
+     *
+     * @return list<string>
      */
     private static function getTagsIntroducingIgnoredNames(PhpDocNode $docNode): array
     {
-        return $docNode->getTemplateTagValues()
-               + $docNode->getTemplateTagValues('@template-covariant')
-               + $docNode->getTypeAliasTagValues() + $docNode->getTypeAliasImportTagValues();
+        $templateNames =
+            array_map(static fn (TemplateTagValueNode $tag): string => $tag->name,
+                $docNode->getTemplateTagValues() + $docNode->getTemplateTagValues('@template-covariant'));
+        $aliasNames = array_map(static fn (TypeAliasTagValueNode $tag): string => $tag->alias, $docNode->getTypeAliasTagValues());
+        $importNames = array_map(static fn (TypeAliasImportTagValueNode $tag): string => $tag->importedAs ?? $tag->importedAlias, $docNode->getTypeAliasImportTagValues());
+
+        return array_values($templateNames + $aliasNames + $importNames);
     }
 }

--- a/src/DefaultBehavior/Ast/Extractors/ClassLikeExtractor.php
+++ b/src/DefaultBehavior/Ast/Extractors/ClassLikeExtractor.php
@@ -52,7 +52,7 @@ final class ClassLikeExtractor implements NikicReferenceExtractorInterface, PHPS
             }
         }
 
-        $resolved = DocParsingHelper::resolvePHPDocWithNativeScope($node, $this->lexer, $this->docParser, $referenceBuilder->getTokenTemplates());
+        $resolved = DocParsingHelper::resolvePHPDocWithNativeScope($node, $this->lexer, $this->docParser, $referenceBuilder->getTokenTemplateLikes());
         if (null === $resolved) {
             return;
         }

--- a/src/DefaultBehavior/Ast/Extractors/ClassMethodExtractor.php
+++ b/src/DefaultBehavior/Ast/Extractors/ClassMethodExtractor.php
@@ -43,7 +43,7 @@ final class ClassMethodExtractor implements NikicReferenceExtractorInterface, PH
 
     public function processNode(Node $node, ReferenceBuilderInterface $referenceBuilder, TypeScope $typeScope): void
     {
-        $resolved = DocParsingHelper::resolvePHPDocWithNativeScope($node, $this->lexer, $this->docParser, $referenceBuilder->getTokenTemplates());
+        $resolved = DocParsingHelper::resolvePHPDocWithNativeScope($node, $this->lexer, $this->docParser, $referenceBuilder->getTokenTemplateLikes());
         if (null === $resolved) {
             return;
         }

--- a/src/DefaultBehavior/Ast/Extractors/ExpressionExtractor.php
+++ b/src/DefaultBehavior/Ast/Extractors/ExpressionExtractor.php
@@ -49,7 +49,7 @@ final class ExpressionExtractor implements NikicReferenceExtractorInterface, PHP
             return;
         }
 
-        $resolved = DocParsingHelper::resolvePHPDocWithNativeScope($node, $this->lexer, $this->docParser, $referenceBuilder->getTokenTemplates());
+        $resolved = DocParsingHelper::resolvePHPDocWithNativeScope($node, $this->lexer, $this->docParser, $referenceBuilder->getTokenTemplateLikes());
         if (null === $resolved) {
             return;
         }

--- a/src/DefaultBehavior/Ast/Extractors/PropertyExtractor.php
+++ b/src/DefaultBehavior/Ast/Extractors/PropertyExtractor.php
@@ -56,7 +56,7 @@ final class PropertyExtractor implements NikicReferenceExtractorInterface, PHPSt
             }
         }
 
-        $resolved = DocParsingHelper::resolvePHPDocWithNativeScope($node, $this->lexer, $this->docParser, $referenceBuilder->getTokenTemplates());
+        $resolved = DocParsingHelper::resolvePHPDocWithNativeScope($node, $this->lexer, $this->docParser, $referenceBuilder->getTokenTemplateLikes());
         if (null === $resolved) {
             return;
         }

--- a/src/DefaultBehavior/Ast/Extractors/VariableExtractor.php
+++ b/src/DefaultBehavior/Ast/Extractors/VariableExtractor.php
@@ -53,7 +53,7 @@ final class VariableExtractor implements NikicReferenceExtractorInterface, PHPSt
             $referenceBuilder->dependency(SuperGlobalToken::from($node->name), $node->getLine(), DependencyType::SUPERGLOBAL_VARIABLE);
         }
 
-        $resolved = DocParsingHelper::resolvePHPDocWithNativeScope($node, $this->lexer, $this->docParser, $referenceBuilder->getTokenTemplates());
+        $resolved = DocParsingHelper::resolvePHPDocWithNativeScope($node, $this->lexer, $this->docParser, $referenceBuilder->getTokenTemplateLikes());
         if (null === $resolved) {
             return;
         }

--- a/src/DefaultBehavior/Ast/Parser/Helpers/NikicFileReferenceVisitor.php
+++ b/src/DefaultBehavior/Ast/Parser/Helpers/NikicFileReferenceVisitor.php
@@ -17,6 +17,7 @@ use PhpParser\Node\Stmt\Trait_;
 use PhpParser\Node\Stmt\Use_;
 use PhpParser\NodeVisitorAbstract;
 use PHPStan\PhpDocParser\Ast\PhpDoc\TemplateTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\TypeAliasTagValueNode;
 use PHPStan\PhpDocParser\Lexer\Lexer;
 use PHPStan\PhpDocParser\Parser\ConstExprParser;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
@@ -54,7 +55,7 @@ class NikicFileReferenceVisitor extends NodeVisitorAbstract
     /**
      * @return list<string>
      */
-    private function templatesFromDocs(Node $node): array
+    private function templateLikesFromDocs(Node $node): array
     {
         $docComment = $node->getDocComment();
         if (null === $docComment) {
@@ -63,14 +64,22 @@ class NikicFileReferenceVisitor extends NodeVisitorAbstract
         $docText = $docComment->getText();
 
         // prevent expensive parsing, when not templates involved.
-        if (!str_contains($docText, '@template')) {
+        if (!str_contains($docText, '@template')
+            && !str_contains($docText, '@template-covariant')
+            && !str_contains($docText, '@phpstan-type')
+        ) {
             return [];
         }
 
         $tokens = new TokenIterator($this->lexer->tokenize($docText));
         $docNode = $this->docParser->parse($tokens);
 
-        return array_values(array_map(static fn (TemplateTagValueNode $tag): string => $tag->name, $docNode->getTemplateTagValues()));
+        $templateNames =
+            array_map(static fn (TemplateTagValueNode $tag): string => $tag->name,
+                $docNode->getTemplateTagValues() + $docNode->getTemplateTagValues('@template-covariant'));
+        $importNames = array_map(static fn (TypeAliasTagValueNode $tag): string => $tag->alias, $docNode->getTypeAliasTagValues());
+
+        return array_values($templateNames + $importNames);
     }
 
     public function enterNode(Node $node)
@@ -96,8 +105,8 @@ class NikicFileReferenceVisitor extends NodeVisitorAbstract
         }
 
         if ($node instanceof Node\FunctionLike) {
-            foreach ($this->templatesFromDocs($node) as $template) {
-                $this->currentReference->removeTokenTemplate($template);
+            foreach ($this->templateLikesFromDocs($node) as $template) {
+                $this->currentReference->removeTokenTemplateLike($template);
             }
         }
 
@@ -115,7 +124,7 @@ class NikicFileReferenceVisitor extends NodeVisitorAbstract
         $name = $this->getReferenceName($node);
         if (null !== $name) {
             $tags = $this->getTags($node);
-            $templateTypes = $this->templatesFromDocs($node);
+            $templateTypes = $this->templateLikesFromDocs($node);
 
             $this->currentReference = match (true) {
                 $node instanceof Node\Stmt\Function_ => $this->fileReferenceBuilder->newFunction($name, $templateTypes, $tags),
@@ -142,8 +151,8 @@ class NikicFileReferenceVisitor extends NodeVisitorAbstract
 
     private function enterFunctionLike(Node\FunctionLike $node): void
     {
-        foreach ($this->templatesFromDocs($node) as $template) {
-            $this->currentReference->addTokenTemplate($template);
+        foreach ($this->templateLikesFromDocs($node) as $template) {
+            $this->currentReference->addTokenTemplateLike($template);
         }
     }
 

--- a/src/DefaultBehavior/Ast/Parser/Helpers/ReferenceBuilder.php
+++ b/src/DefaultBehavior/Ast/Parser/Helpers/ReferenceBuilder.php
@@ -22,13 +22,13 @@ abstract class ReferenceBuilder implements ReferenceBuilderInterface
     protected array $dependencies = [];
 
     /**
-     * @param list<string> $tokenTemplates
+     * @param list<string> $tokenTemplateLikes
      */
-    protected function __construct(protected array $tokenTemplates, protected string $filepath) {}
+    protected function __construct(protected array $tokenTemplateLikes, protected string $filepath) {}
 
-    final public function getTokenTemplates(): array
+    final public function getTokenTemplateLikes(): array
     {
-        return $this->tokenTemplates;
+        return $this->tokenTemplateLikes;
     }
 
     protected function createContext(int $occursAtLine, DependencyType $type): DependencyContext
@@ -50,16 +50,16 @@ abstract class ReferenceBuilder implements ReferenceBuilderInterface
         return $this;
     }
 
-    public function addTokenTemplate(string $tokenTemplate): void
+    public function addTokenTemplateLike(string $tokenTemplateLike): void
     {
-        $this->tokenTemplates[] = $tokenTemplate;
+        $this->tokenTemplateLikes[] = $tokenTemplateLike;
     }
 
-    public function removeTokenTemplate(string $tokenTemplate): void
+    public function removeTokenTemplateLike(string $tokenTemplateLike): void
     {
-        $key = array_search($tokenTemplate, $this->tokenTemplates, true);
+        $key = array_search($tokenTemplateLike, $this->tokenTemplateLikes, true);
         if (false !== $key) {
-            unset($this->tokenTemplates[$key]);
+            unset($this->tokenTemplateLikes[$key]);
         }
     }
 }

--- a/tests/Core/Ast/Parser/AnnotationReferenceExtractorTest.php
+++ b/tests/Core/Ast/Parser/AnnotationReferenceExtractorTest.php
@@ -31,9 +31,11 @@ final class AnnotationReferenceExtractorTest extends TestCase
         $astClassReferences = $astFileReference->classLikeReferences;
         $annotationDependency = $astClassReferences[0]->dependencies;
 
-        self::assertCount(3, $astClassReferences);
+        self::assertCount(5, $astClassReferences);
         self::assertCount(9, $annotationDependency);
         self::assertCount(0, $astClassReferences[1]->dependencies);
+        self::assertCount(0, $astClassReferences[3]->dependencies);
+        self::assertCount(0, $astClassReferences[4]->dependencies);
 
         self::assertSame(
             'Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures\AnnotationDependencyChild',

--- a/tests/Core/Ast/Parser/Fixtures/AnnotationDependency.php
+++ b/tests/Core/Ast/Parser/Fixtures/AnnotationDependency.php
@@ -88,3 +88,29 @@ trait TestTrait
         return 123;
     }
 }
+
+/**
+ * @template-covariant TEntityId
+ */
+interface TemplateInterface
+{
+    /**
+     * @return TEntityId
+     */
+    public function getId(): mixed;
+
+}
+
+/**
+ * @phpstan-type arrayAlias array<string, mixed>
+ */
+class SomeClass
+{
+    /**
+     * @return arrayAlias
+     */
+    private function someMethod(): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Closes: #1399

Expand the list of tags that produce placeholder names that should be ignored by Deptrac from `@template` to also include `@template-covariant`, `@phpstan-type` and `@phpstan-import-type`.

This is coincidentally only necessary for Nikic Parser and not PHPStan parser. That does it out of the box. Also, this is a whack-a-mole, as the list of these types of tags can expand in the future.