### PR TITLE
Support phpstan/phpdoc-parser v1 along with v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "nikic/php-parser": "^5",
         "phpdocumentor/graphviz": "^2.1",
         "phpdocumentor/type-resolver": "^1.9.0",
-        "phpstan/phpdoc-parser": "^2.1.0",
+        "phpstan/phpdoc-parser": "^1.5.0|^2.1.0",
         "phpstan/phpstan": "^2.0",
         "psr/container": "^2.0",
         "psr/event-dispatcher": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8e8703174836871bcb74debcb111850f",
+    "content-hash": "29e9653b0850b31dc4c6af8773ebfb7a",
     "packages": [
         {
             "name": "composer/pcre",
@@ -2813,7 +2813,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/src/DefaultBehavior/Ast/DocParsingHelper.php
+++ b/src/DefaultBehavior/Ast/DocParsingHelper.php
@@ -12,11 +12,47 @@ use PHPStan\PhpDoc\ResolvedPhpDocBlock;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\TemplateTagValueNode;
 use PHPStan\PhpDocParser\Lexer\Lexer;
+use PHPStan\PhpDocParser\Parser\ConstExprParser;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use PHPStan\PhpDocParser\Parser\TokenIterator;
+use PHPStan\PhpDocParser\Parser\TypeParser;
+use PHPStan\PhpDocParser\ParserConfig;
 
 class DocParsingHelper
 {
+    /**
+     * @return array{Lexer, PhpDocParser}
+     */
+    public static function create(): array
+    {
+        if (class_exists(ParserConfig::class)) {
+            $config = new ParserConfig(usedAttributes: ['lines' => true, 'indexes' => true]);
+            $lexer = new Lexer($config);
+            $constExprParser = new ConstExprParser($config);
+            $docParser = new PhpDocParser($config, new TypeParser($config, $constExprParser), $constExprParser);
+        } else {
+            // For phpstan/phpdoc-parser v1
+
+            /**
+             * @psalm-suppress TooFewArguments
+             * @psalm-suppress InvalidArgument
+             *
+             * @phpstan-ignore-next-line
+             */
+            $lexer = new Lexer();
+
+            /**
+             * @psalm-suppress TooFewArguments
+             * @psalm-suppress InvalidArgument
+             *
+             * @phpstan-ignore-next-line
+             */
+            $docParser = new PhpDocParser(new TypeParser(), new ConstExprParser());
+        }
+
+        return [$lexer, $docParser];
+    }
+
     public static function resolvePHPDocWithPHPStanScope(Node $node, PhpStanContainerDecorator $phpStanContainer, MutatingScope $scope): ?ResolvedPhpDocBlock
     {
         $docComment = $node->getDocComment();

--- a/src/DefaultBehavior/Ast/Extractors/ClassLikeExtractor.php
+++ b/src/DefaultBehavior/Ast/Extractors/ClassLikeExtractor.php
@@ -18,10 +18,7 @@ use PhpParser\Node\Stmt\ClassLike;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PropertyTagValueNode;
 use PHPStan\PhpDocParser\Lexer\Lexer;
-use PHPStan\PhpDocParser\Parser\ConstExprParser;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
-use PHPStan\PhpDocParser\Parser\TypeParser;
-use PHPStan\PhpDocParser\ParserConfig;
 
 /**
  * @implements NikicReferenceExtractorInterface<ClassLike>
@@ -36,10 +33,7 @@ final class ClassLikeExtractor implements NikicReferenceExtractorInterface, PHPS
         private readonly PhpStanContainerDecorator $phpStanContainer,
         private readonly TypeResolverInterface $typeResolver,
     ) {
-        $config = new ParserConfig(usedAttributes: ['lines' => true, 'indexes' => true]);
-        $this->lexer = new Lexer($config);
-        $constExprParser = new ConstExprParser($config);
-        $this->docParser = new PhpDocParser($config, new TypeParser($config, $constExprParser), $constExprParser);
+        [$this->lexer, $this->docParser] = DocParsingHelper::create();
     }
 
     public function processNode(Node $node, ReferenceBuilderInterface $referenceBuilder, TypeScope $typeScope): void

--- a/src/DefaultBehavior/Ast/Extractors/ClassMethodExtractor.php
+++ b/src/DefaultBehavior/Ast/Extractors/ClassMethodExtractor.php
@@ -17,10 +17,7 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\PhpDocParser\Lexer\Lexer;
-use PHPStan\PhpDocParser\Parser\ConstExprParser;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
-use PHPStan\PhpDocParser\Parser\TypeParser;
-use PHPStan\PhpDocParser\ParserConfig;
 
 /**
  * @implements NikicReferenceExtractorInterface<ClassMethod>
@@ -35,10 +32,7 @@ final class ClassMethodExtractor implements NikicReferenceExtractorInterface, PH
         private readonly PhpStanContainerDecorator $phpStanContainer,
         private readonly TypeResolverInterface $typeResolver,
     ) {
-        $config = new ParserConfig(usedAttributes: ['lines' => true, 'indexes' => true]);
-        $this->lexer = new Lexer($config);
-        $constExprParser = new ConstExprParser($config);
-        $this->docParser = new PhpDocParser($config, new TypeParser($config, $constExprParser), $constExprParser);
+        [$this->lexer, $this->docParser] = DocParsingHelper::create();
     }
 
     public function processNode(Node $node, ReferenceBuilderInterface $referenceBuilder, TypeScope $typeScope): void

--- a/src/DefaultBehavior/Ast/Extractors/ExpressionExtractor.php
+++ b/src/DefaultBehavior/Ast/Extractors/ExpressionExtractor.php
@@ -16,10 +16,7 @@ use Deptrac\Deptrac\DefaultBehavior\Ast\Parser\Helpers\PhpStanContainerDecorator
 use PhpParser\Node;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\PhpDocParser\Lexer\Lexer;
-use PHPStan\PhpDocParser\Parser\ConstExprParser;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
-use PHPStan\PhpDocParser\Parser\TypeParser;
-use PHPStan\PhpDocParser\ParserConfig;
 
 /**
  * @see https://github.com/nikic/PHP-Parser/commit/4e27a17cd855b36abe0199efb81be143b144f40d#diff-4034fc485172f50147405c293a9d86685b0f333e69b666de5492da37406186afL44 for the change in nikic/php-parser
@@ -37,10 +34,7 @@ final class ExpressionExtractor implements NikicReferenceExtractorInterface, PHP
         private readonly PhpStanContainerDecorator $phpStanContainer,
         private readonly TypeResolverInterface $typeResolver,
     ) {
-        $config = new ParserConfig(usedAttributes: ['lines' => true, 'indexes' => true]);
-        $this->lexer = new Lexer($config);
-        $constExprParser = new ConstExprParser($config);
-        $this->docParser = new PhpDocParser($config, new TypeParser($config, $constExprParser), $constExprParser);
+        [$this->lexer, $this->docParser] = DocParsingHelper::create();
     }
 
     public function processNode(Node $node, ReferenceBuilderInterface $referenceBuilder, TypeScope $typeScope): void

--- a/src/DefaultBehavior/Ast/Extractors/PropertyExtractor.php
+++ b/src/DefaultBehavior/Ast/Extractors/PropertyExtractor.php
@@ -17,10 +17,7 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\PhpDocParser\Lexer\Lexer;
-use PHPStan\PhpDocParser\Parser\ConstExprParser;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
-use PHPStan\PhpDocParser\Parser\TypeParser;
-use PHPStan\PhpDocParser\ParserConfig;
 
 /**
  * @implements NikicReferenceExtractorInterface<Property>
@@ -35,10 +32,7 @@ final class PropertyExtractor implements NikicReferenceExtractorInterface, PHPSt
         private readonly PhpStanContainerDecorator $phpStanContainer,
         private readonly TypeResolverInterface $typeResolver,
     ) {
-        $config = new ParserConfig(usedAttributes: ['lines' => true, 'indexes' => true]);
-        $this->lexer = new Lexer($config);
-        $constExprParser = new ConstExprParser($config);
-        $this->docParser = new PhpDocParser($config, new TypeParser($config, $constExprParser), $constExprParser);
+        [$this->lexer, $this->docParser] = DocParsingHelper::create();
     }
 
     public function processNode(Node $node, ReferenceBuilderInterface $referenceBuilder, TypeScope $typeScope): void

--- a/src/DefaultBehavior/Ast/Extractors/VariableExtractor.php
+++ b/src/DefaultBehavior/Ast/Extractors/VariableExtractor.php
@@ -17,10 +17,7 @@ use Deptrac\Deptrac\DefaultBehavior\Ast\Parser\Helpers\PhpStanContainerDecorator
 use PhpParser\Node;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\PhpDocParser\Lexer\Lexer;
-use PHPStan\PhpDocParser\Parser\ConstExprParser;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
-use PHPStan\PhpDocParser\Parser\TypeParser;
-use PHPStan\PhpDocParser\ParserConfig;
 
 /**
  * @implements NikicReferenceExtractorInterface<Node\Expr\Variable>
@@ -39,10 +36,7 @@ final class VariableExtractor implements NikicReferenceExtractorInterface, PHPSt
         private readonly PhpStanContainerDecorator $phpStanContainer,
         private readonly TypeResolverInterface $typeResolver,
     ) {
-        $config = new ParserConfig(usedAttributes: ['lines' => true, 'indexes' => true]);
-        $this->lexer = new Lexer($config);
-        $constExprParser = new ConstExprParser($config);
-        $this->docParser = new PhpDocParser($config, new TypeParser($config, $constExprParser), $constExprParser);
+        [$this->lexer, $this->docParser] = DocParsingHelper::create();
         $this->allowedNames = SuperGlobalToken::allowedNames();
     }
 

--- a/src/DefaultBehavior/Ast/Parser/Helpers/NikicFileReferenceVisitor.php
+++ b/src/DefaultBehavior/Ast/Parser/Helpers/NikicFileReferenceVisitor.php
@@ -6,6 +6,7 @@ namespace Deptrac\Deptrac\DefaultBehavior\Ast\Parser\Helpers;
 
 use Deptrac\Deptrac\Contract\Ast\NikicReferenceExtractorInterface;
 use Deptrac\Deptrac\Contract\Ast\TypeScope;
+use Deptrac\Deptrac\DefaultBehavior\Ast\DocParsingHelper;
 use PhpParser\Node;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Class_;
@@ -18,11 +19,8 @@ use PhpParser\Node\Stmt\Use_;
 use PhpParser\NodeVisitorAbstract;
 use PHPStan\PhpDocParser\Ast\PhpDoc\TemplateTagValueNode;
 use PHPStan\PhpDocParser\Lexer\Lexer;
-use PHPStan\PhpDocParser\Parser\ConstExprParser;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use PHPStan\PhpDocParser\Parser\TokenIterator;
-use PHPStan\PhpDocParser\Parser\TypeParser;
-use PHPStan\PhpDocParser\ParserConfig;
 
 class NikicFileReferenceVisitor extends NodeVisitorAbstract
 {
@@ -43,10 +41,7 @@ class NikicFileReferenceVisitor extends NodeVisitorAbstract
         NikicReferenceExtractorInterface ...$dependencyResolvers,
     ) {
         $this->currentTypeScope = new TypeScope('');
-        $config = new ParserConfig(usedAttributes: ['lines' => true, 'indexes' => true]);
-        $this->lexer = new Lexer($config);
-        $constExprParser = new ConstExprParser($config);
-        $this->docParser = new PhpDocParser($config, new TypeParser($config, $constExprParser), $constExprParser);
+        [$this->lexer, $this->docParser] = DocParsingHelper::create();
         $this->dependencyResolvers = $dependencyResolvers;
         $this->currentReference = $fileReferenceBuilder;
     }

--- a/src/DefaultBehavior/Ast/Parser/Helpers/PhpStanFileReferenceVisitor.php
+++ b/src/DefaultBehavior/Ast/Parser/Helpers/PhpStanFileReferenceVisitor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Deptrac\Deptrac\DefaultBehavior\Ast\Parser\Helpers;
 
 use Deptrac\Deptrac\Contract\Ast\PHPStanReferenceExtractorInterface;
+use Deptrac\Deptrac\DefaultBehavior\Ast\DocParsingHelper;
 use PhpParser\Node;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Class_;
@@ -16,11 +17,8 @@ use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\ScopeContext;
 use PHPStan\Analyser\ScopeFactory;
 use PHPStan\PhpDocParser\Lexer\Lexer;
-use PHPStan\PhpDocParser\Parser\ConstExprParser;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use PHPStan\PhpDocParser\Parser\TokenIterator;
-use PHPStan\PhpDocParser\Parser\TypeParser;
-use PHPStan\PhpDocParser\ParserConfig;
 use PHPStan\Reflection\ReflectionProvider;
 
 class PhpStanFileReferenceVisitor extends NodeVisitorAbstract
@@ -49,10 +47,7 @@ class PhpStanFileReferenceVisitor extends NodeVisitorAbstract
         $this->dependencyResolvers = $dependencyResolvers;
         $this->currentReference = $fileReferenceBuilder;
         $this->scope = $this->scopeFactory->create(ScopeContext::create($this->file));
-        $config = new ParserConfig(usedAttributes: ['lines' => true, 'indexes' => true]);
-        $this->lexer = new Lexer($config);
-        $constExprParser = new ConstExprParser($config);
-        $this->docParser = new PhpDocParser($config, new TypeParser($config, $constExprParser), $constExprParser);
+        [$this->lexer, $this->docParser] = DocParsingHelper::create();
     }
 
     public function enterNode(Node $node)

--- a/tests/Core/Ast/Parser/TypeResolverTest.php
+++ b/tests/Core/Ast/Parser/TypeResolverTest.php
@@ -22,10 +22,30 @@ final class TypeResolverTest extends TestCase
     {
         parent::setUp();
 
-        $config = new ParserConfig(usedAttributes: ['lines' => true, 'indexes' => true]);
-        $this->lexer = new Lexer($config);
-        $constExprParser = new ConstExprParser($config);
-        $this->typeParser = new TypeParser($config, $constExprParser);
+        if (class_exists(ParserConfig::class)) {
+            $config = new ParserConfig(usedAttributes: ['lines' => true, 'indexes' => true]);
+            $this->lexer = new Lexer($config);
+            $constExprParser = new ConstExprParser($config);
+            $this->typeParser = new TypeParser($config, $constExprParser);
+        } else {
+            // For phpstan/phpdoc-parser v1
+
+            /**
+             * @psalm-suppress TooFewArguments
+             * @psalm-suppress InvalidArgument
+             *
+             * @phpstan-ignore-next-line
+             */
+            $this->lexer = new Lexer();
+
+            /**
+             * @psalm-suppress TooFewArguments
+             * @psalm-suppress InvalidArgument
+             *
+             * @phpstan-ignore-next-line
+             */
+            $this->typeParser = new TypeParser(new ConstExprParser());
+        }
     }
 
     /**


### PR DESCRIPTION
Support for v1 was removed https://github.com/deptrac/deptrac/pull/1494.

Because deptrac is a utility tool and is not supposed to introduce compatibility issues with application packages, I suggest temporarily retaining support for phpstan/phpdoc-parser v1. This approach was taken in Symfony, and I believe it is a good solution https://github.com/symfony/type-info/commit/51535dde21c7abf65c9d000a30bb15f6478195e6

Partially resolves https://github.com/deptrac/deptrac/issues/1505.