### PR TITLE
fix: add missing return types to eventsubscriber

### DIFF
--- a/src/DefaultBehavior/Analyser/AllowDependencyHandler.php
+++ b/src/DefaultBehavior/Analyser/AllowDependencyHandler.php
@@ -10,7 +10,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class AllowDependencyHandler implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             ProcessEvent::class => ['invoke', -100],

--- a/src/DefaultBehavior/Analyser/DependsOnDisallowedLayer.php
+++ b/src/DefaultBehavior/Analyser/DependsOnDisallowedLayer.php
@@ -16,7 +16,7 @@ final class DependsOnDisallowedLayer implements ViolationCreatingInterface
 {
     public function __construct(private readonly EventHelper $eventHelper) {}
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             ProcessEvent::class => ['invoke', -1],

--- a/src/DefaultBehavior/Analyser/DependsOnInternalToken.php
+++ b/src/DefaultBehavior/Analyser/DependsOnInternalToken.php
@@ -23,7 +23,7 @@ final class DependsOnInternalToken implements ViolationCreatingInterface
         $this->internalTag = $config['internal_tag'];
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             ProcessEvent::class => ['invoke', -2],

--- a/src/DefaultBehavior/Analyser/DependsOnPrivateLayer.php
+++ b/src/DefaultBehavior/Analyser/DependsOnPrivateLayer.php
@@ -12,7 +12,7 @@ final class DependsOnPrivateLayer implements ViolationCreatingInterface
 {
     public function __construct(private readonly EventHelper $eventHelper) {}
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             ProcessEvent::class => ['invoke', -3],

--- a/src/DefaultBehavior/Analyser/MatchingLayersHandler.php
+++ b/src/DefaultBehavior/Analyser/MatchingLayersHandler.php
@@ -22,7 +22,7 @@ final class MatchingLayersHandler implements EventSubscriberInterface
         $event->stopPropagation();
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             ProcessEvent::class => ['invoke', 1],

--- a/src/DefaultBehavior/Analyser/UncoveredDependentHandler.php
+++ b/src/DefaultBehavior/Analyser/UncoveredDependentHandler.php
@@ -41,7 +41,7 @@ final class UncoveredDependentHandler implements EventSubscriberInterface
         return isset(PhpStormStubsMap::CLASSES[$tokenString]) || 'ReturnTypeWillChange' === $tokenString;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             ProcessEvent::class => ['invoke', 2],

--- a/src/DefaultBehavior/Analyser/UnmatchedSkippedViolations.php
+++ b/src/DefaultBehavior/Analyser/UnmatchedSkippedViolations.php
@@ -26,7 +26,7 @@ final class UnmatchedSkippedViolations implements EventSubscriberInterface
         }
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             PostProcessEvent::class => ['invoke'],

--- a/tests/Supportive/OutputFormatter/data/DummyViolationCreatingRule.php
+++ b/tests/Supportive/OutputFormatter/data/DummyViolationCreatingRule.php
@@ -8,7 +8,7 @@ use Deptrac\Deptrac\Contract\Analyser\ViolationCreatingInterface;
 
 class DummyViolationCreatingRule implements ViolationCreatingInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [];
     }


### PR DESCRIPTION
return types where added in symfony 8.0