### PR TITLE
chore: add Rector and modernize code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ PHPSTAN = ./tools/phpstan/bin/phpstan
 PSALM = ./tools/psalm/bin/psalm
 PHPUNIT = ./tools/phpunit/bin/phpunit -c .
 INFECTION = ./tools/infection/bin/roave-infection-static-analysis-plugin
+RECTOR = ./tools/rector/bin/rector
 
 update:
 	$(CONTAINER) build --pull --build-arg UID=$(UID)
@@ -48,6 +49,12 @@ phpstan: install ## Performs static code analysis using phpstan
 
 psalm: install ## Performs static code analysis using psalm
 	$(PSALM)
+
+rector-check: install ## Checks for automated code refactoring using rector
+	$(RECTOR) process --dry-run
+
+rector: install ## Performs automated code refactoring using rector
+	$(RECTOR) process
 
 test: install ## run our testsuite
 	$(PHPUNIT)

--- a/baseline.xml
+++ b/baseline.xml
@@ -28,6 +28,34 @@
       <code><![CDATA[list<T>]]></code>
     </InvalidReturnType>
   </file>
+  <file src="src/Core/Ast/Parser/TypeResolver.php">
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[array]]></code>
+      <code><![CDATA[match (true) {
+            $type instanceof FullyQualified => [(string) $type],
+            $type instanceof NullableType => $this->resolvePropertyType($type->type),
+            $type instanceof UnionType || $type instanceof IntersectionType => array_merge(
+                [],
+                ...array_map(
+                    $this->resolvePropertyType(...),
+                    $type->types
+                )
+            ),
+            default => [],
+        }]]></code>
+    </MixedReturnTypeCoercion>
+    <NamedArgumentNotAllowed>
+      <code><![CDATA[array_map(static fn ($type): array => self::resolveType($type, $scope), $type->types)]]></code>
+    </NamedArgumentNotAllowed>
+  </file>
+  <file src="src/DefaultBehavior/Ast/Extractors/ClassMethodExtractor.php">
+    <RedundantCondition>
+      <code><![CDATA[$resolvedPhpDoc->getThrowsTag()?->getType()->getReferencedClasses()]]></code>
+    </RedundantCondition>
+    <TypeDoesNotContainNull>
+      <code><![CDATA[[]]]></code>
+    </TypeDoesNotContainNull>
+  </file>
   <file src="src/DefaultBehavior/Layer/BoolCollector.php">
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[!$configuration['must']]]></code>
@@ -115,22 +143,18 @@
       <code><![CDATA[$this->astMapExtractor->extract()]]></code>
     </RedundantPropertyInitializationCheck>
   </file>
+  <file src="src/DefaultBehavior/OutputFormatter/BaselineOutputFormatter.php">
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[array<string,list<string>>]]></code>
+      <code><![CDATA[array_map(
+            array_values(...),
+            $violations
+        )]]></code>
+    </MixedReturnTypeCoercion>
+  </file>
   <file src="src/Supportive/Console/Command/DebugLayerRunner.php">
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[$layer]]></code>
     </RiskyTruthyFalsyComparison>
   </file>
-    <file src="src/Core/Ast/Parser/TypeResolver.php">
-        <NamedArgumentNotAllowed>
-            <code><![CDATA[array_map(static fn ($type): array => self::resolveType($type, $scope), $type->types)]]></code>
-        </NamedArgumentNotAllowed>
-    </file>
-    <file src="src/DefaultBehavior/Ast/Extractors/ClassMethodExtractor.php">
-        <RedundantCondition>
-            <code><![CDATA[$resolvedPhpDoc->getThrowsTag()?->getType()->getReferencedClasses()]]></code>
-        </RedundantCondition>
-        <TypeDoesNotContainNull>
-            <code><![CDATA[[]]]></code>
-        </TypeDoesNotContainNull>
-    </file>
 </files>

--- a/rector.php
+++ b/rector.php
@@ -13,8 +13,7 @@ return RectorConfig::configure()
         './docs',
         './tests/*/Fixtures/*',
     ])
-    // ->withPhpSets(php81: true)
-    ->withPhpLevel(1)
+    ->withPhpSets(php81: true)
     ->withPreparedSets(
         // typeDeclarations: true,
         // privatization: true,

--- a/rector.php
+++ b/rector.php
@@ -22,6 +22,6 @@ return RectorConfig::configure()
         // symfony: true,
         // phpunit: true,
     )
-    ->withImportNames(importShortClasses: false)
+    // ->withImportNames(importShortClasses: false)
     ->withParallel()
 ;

--- a/rector.php
+++ b/rector.php
@@ -1,6 +1,7 @@
 <?php
 
 use Rector\Config\RectorConfig;
+use Rector\Php81\Rector\ClassMethod\NewInInitializerRector;
 use Rector\ValueObject\PhpVersion;
 
 return RectorConfig::configure()
@@ -12,6 +13,8 @@ return RectorConfig::configure()
         './tools',
         './docs',
         './tests/*/Fixtures/*',
+
+         NewInInitializerRector::class,
     ])
     ->withPhpSets(php81: true)
     ->withPreparedSets(

--- a/src/Contract/Analyser/AnalysisResult.php
+++ b/src/Contract/Analyser/AnalysisResult.php
@@ -35,7 +35,7 @@ final class AnalysisResult
 
     public function __construct(?DateTimeImmutable $analysisComplete = null)
     {
-        $this->analysisComplete = null === $analysisComplete ? new DateTimeImmutable() : $analysisComplete;
+        $this->analysisComplete = $analysisComplete ?? new DateTimeImmutable();
     }
 
     public function addRule(RuleInterface $rule): void

--- a/src/Contract/Config/Collector/TagValueRegexConfig.php
+++ b/src/Contract/Config/Collector/TagValueRegexConfig.php
@@ -10,7 +10,7 @@ final class TagValueRegexConfig extends CollectorConfig
     protected CollectorType $collectorType = CollectorType::TYPE_TAG_VALUE_REGEX;
 
     public function __construct(
-        private string $tag,
+        private readonly string $tag,
         private ?string $value = null,
     ) {}
 

--- a/src/Contract/Config/Layer.php
+++ b/src/Contract/Config/Layer.php
@@ -8,12 +8,10 @@ final class Layer
 {
     /** @var array<CollectorConfig> */
     private array $collectors = [];
-    public string $name;
 
     /** @param  array<CollectorConfig> $collectorConfig */
-    public function __construct(string $name, array $collectorConfig = [])
+    public function __construct(public string $name, array $collectorConfig = [])
     {
-        $this->name = $name;
         $this->collectors(...$collectorConfig);
     }
 

--- a/src/Contract/Config/Ruleset.php
+++ b/src/Contract/Config/Ruleset.php
@@ -6,15 +6,12 @@ namespace Deptrac\Deptrac\Contract\Config;
 
 final class Ruleset
 {
-    public Layer $layerConfig;
-
     /** @var array<Layer> */
     private array $accessableLayers = [];
 
     /** @param  array<Layer> $layerConfigs */
-    public function __construct(Layer $layerConfig, array $layerConfigs)
+    public function __construct(public Layer $layerConfig, array $layerConfigs)
     {
-        $this->layerConfig = $layerConfig;
         $this->accesses(...$layerConfigs);
     }
 

--- a/src/Contract/Result/OutputResult.php
+++ b/src/Contract/Result/OutputResult.php
@@ -30,7 +30,12 @@ final class OutputResult
 
     public static function fromAnalysisResult(AnalysisResult $analysisResult): self
     {
-        return new self($analysisResult->rules(), $analysisResult->errors(), $analysisResult->warnings(), $analysisResult->analysisComplete);
+        return new self(
+            $analysisResult->rules(),
+            $analysisResult->errors(),
+            $analysisResult->warnings(),
+            $analysisResult->analysisComplete,
+        );
     }
 
     /**

--- a/src/Core/Ast/Parser/TypeResolver.php
+++ b/src/Core/Ast/Parser/TypeResolver.php
@@ -126,7 +126,7 @@ class TypeResolver implements TypeResolverInterface
             $type instanceof UnionType || $type instanceof IntersectionType => array_merge(
                 [],
                 ...array_map(
-                    fn (Identifier|Name|IntersectionType $typeNode): array => $this->resolvePropertyType($typeNode),
+                    $this->resolvePropertyType(...),
                     $type->types
                 )
             ),
@@ -141,7 +141,7 @@ class TypeResolver implements TypeResolverInterface
     {
         return match (true) {
             $resolvedType instanceof Object_ => ($fqsen = $resolvedType->getFqsen()) ? [(string) $fqsen] : [],
-            $resolvedType instanceof Compound => array_merge([], ...array_map(fn (Type $type) => $this->resolveReflectionType($type), iterator_to_array($resolvedType))),
+            $resolvedType instanceof Compound => array_merge([], ...array_map($this->resolveReflectionType(...), iterator_to_array($resolvedType))),
             default => [],
         };
     }

--- a/src/DefaultBehavior/Analyser/DependsOnInternalToken.php
+++ b/src/DefaultBehavior/Analyser/DependsOnInternalToken.php
@@ -11,15 +11,15 @@ use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeReference;
 
 final class DependsOnInternalToken implements ViolationCreatingInterface
 {
-    private ?string $internalTag;
+    private readonly ?string $internalTag;
 
     /**
      * @param array{internal_tag:string|null, ...} $config
      */
     public function __construct(
         private readonly EventHelper $eventHelper,
-        array $config)
-    {
+        array $config,
+    ) {
         $this->internalTag = $config['internal_tag'];
     }
 

--- a/src/DefaultBehavior/Ast/Extractors/VariableExtractor.php
+++ b/src/DefaultBehavior/Ast/Extractors/VariableExtractor.php
@@ -28,7 +28,7 @@ final class VariableExtractor implements NikicReferenceExtractorInterface, PHPSt
     /**
      * @var list<string>
      */
-    private array $allowedNames;
+    private readonly array $allowedNames;
     private readonly Lexer $lexer;
     private readonly PhpDocParser $docParser;
 

--- a/src/DefaultBehavior/Ast/Parser/Helpers/PhpStanContainerDecorator.php
+++ b/src/DefaultBehavior/Ast/Parser/Helpers/PhpStanContainerDecorator.php
@@ -15,7 +15,7 @@ use Symfony\Component\Filesystem\Path;
 
 class PhpStanContainerDecorator
 {
-    private Container $container;
+    private readonly Container $container;
 
     /**
      * @param list<string> $paths

--- a/src/DefaultBehavior/OutputFormatter/BaselineOutputFormatter.php
+++ b/src/DefaultBehavior/OutputFormatter/BaselineOutputFormatter.php
@@ -74,7 +74,7 @@ final class BaselineOutputFormatter implements OutputFormatterInterface
         }
 
         return array_map(
-            static fn (array $dependencies): array => array_values($dependencies),
+            array_values(...),
             $violations
         );
     }

--- a/src/Supportive/Console/Command/DebugDependenciesRunner.php
+++ b/src/Supportive/Console/Command/DebugDependenciesRunner.php
@@ -26,7 +26,7 @@ final class DebugDependenciesRunner
             foreach ($dependencies as $targetLayer => $violations) {
                 $output->getStyle()->table(
                     [$targetLayer],
-                    array_map(fn (Uncovered $violation): array => $this->formatRow($violation), $violations)
+                    array_map($this->formatRow(...), $violations)
                 );
             }
         } catch (AnalyserException $e) {

--- a/src/Supportive/DependencyInjection/ServiceContainerBuilder.php
+++ b/src/Supportive/DependencyInjection/ServiceContainerBuilder.php
@@ -91,7 +91,7 @@ final class ServiceContainerBuilder
         /** @var ?string $cacheFileFromConfig */
         $cacheFileFromConfig = $container->getExtensionConfig('deptrac')[0]['cache_file'] ?? null; // if there is any
         $cache = $cacheOverride ?? $cacheFileFromConfig; // override if there is a no-cache or path to file
-        $cache = $cache ?? '.deptrac.cache'; // override if there is no file specified and needs one
+        $cache ??= '.deptrac.cache'; // override if there is no file specified and needs one
 
         if (false !== $cache) {
             if ($clearCache) {

--- a/tests/Core/Ast/AstMapGeneratorTest.php
+++ b/tests/Core/Ast/AstMapGeneratorTest.php
@@ -133,9 +133,7 @@ final class AstMapGeneratorTest extends TestCase
                 'LogicException',
             ],
             array_map(
-                static function (DependencyToken $dependency) {
-                    return $dependency->token->toString();
-                },
+                static fn (DependencyToken $dependency) => $dependency->token->toString(),
                 $astMap->getFileReferences()[$filePath]->dependencies
             )
         );
@@ -150,7 +148,7 @@ final class AstMapGeneratorTest extends TestCase
             return [];
         }
 
-        return array_map('strval', $classReference->inherits);
+        return array_map(strval(...), $classReference->inherits);
     }
 
     /**

--- a/tests/Core/Ast/Parser/AnnotationReferenceExtractorTest.php
+++ b/tests/Core/Ast/Parser/AnnotationReferenceExtractorTest.php
@@ -18,6 +18,9 @@ use Deptrac\Deptrac\DefaultBehavior\Ast\Parser\PhpStanParser;
 use PhpParser\ParserFactory;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Finder\SplFileInfo;
+use Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures\AnnotationDependencyChild;
 
 final class AnnotationReferenceExtractorTest extends TestCase
 {
@@ -37,7 +40,7 @@ final class AnnotationReferenceExtractorTest extends TestCase
         self::assertCount(0, $astClassReferences[4]->dependencies);
 
         self::assertSame(
-            'Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures\AnnotationDependencyChild',
+            AnnotationDependencyChild::class,
             $annotationDependency[0]->token->toString()
         );
         self::assertSame($filePath, $annotationDependency[0]->context->fileOccurrence->filepath);
@@ -45,7 +48,7 @@ final class AnnotationReferenceExtractorTest extends TestCase
         self::assertSame('variable', $annotationDependency[0]->context->dependencyType->value);
 
         self::assertSame(
-            'Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures\AnnotationDependencyChild',
+            AnnotationDependencyChild::class,
             $annotationDependency[1]->token->toString()
         );
         self::assertSame($filePath, $annotationDependency[1]->context->fileOccurrence->filepath);
@@ -53,7 +56,7 @@ final class AnnotationReferenceExtractorTest extends TestCase
         self::assertSame('variable', $annotationDependency[1]->context->dependencyType->value);
 
         self::assertSame(
-            'Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures\AnnotationDependencyChild',
+            AnnotationDependencyChild::class,
             $annotationDependency[2]->token->toString()
         );
         self::assertSame($filePath, $annotationDependency[2]->context->fileOccurrence->filepath);
@@ -61,7 +64,7 @@ final class AnnotationReferenceExtractorTest extends TestCase
         self::assertSame('variable', $annotationDependency[2]->context->dependencyType->value);
 
         self::assertSame(
-            'Symfony\Component\Console\Exception\RuntimeException',
+            RuntimeException::class,
             $annotationDependency[3]->token->toString()
         );
         self::assertSame($filePath, $annotationDependency[3]->context->fileOccurrence->filepath);
@@ -69,7 +72,7 @@ final class AnnotationReferenceExtractorTest extends TestCase
         self::assertSame('variable', $annotationDependency[3]->context->dependencyType->value);
 
         self::assertSame(
-            'Symfony\Component\Finder\SplFileInfo',
+            SplFileInfo::class,
             $annotationDependency[4]->token->toString()
         );
         self::assertSame($filePath, $annotationDependency[4]->context->fileOccurrence->filepath);
@@ -77,7 +80,7 @@ final class AnnotationReferenceExtractorTest extends TestCase
         self::assertSame('parameter', $annotationDependency[4]->context->dependencyType->value);
 
         self::assertSame(
-            'Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures\AnnotationDependencyChild',
+            AnnotationDependencyChild::class,
             $annotationDependency[5]->token->toString()
         );
         self::assertSame($filePath, $annotationDependency[5]->context->fileOccurrence->filepath);

--- a/tests/Core/Ast/Parser/AnonymousClassExtractorTest.php
+++ b/tests/Core/Ast/Parser/AnonymousClassExtractorTest.php
@@ -14,6 +14,8 @@ use Deptrac\Deptrac\DefaultBehavior\Ast\Parser\PhpStanParser;
 use PhpParser\ParserFactory;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures\ClassA;
+use Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures\InterfaceC;
 
 final class AnonymousClassExtractorTest extends TestCase
 {
@@ -34,7 +36,7 @@ final class AnonymousClassExtractorTest extends TestCase
         $dependencies = $astClassReferences[2]->dependencies;
 
         self::assertSame(
-            'Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures\ClassA',
+            ClassA::class,
             $dependencies[0]->token->toString()
         );
         self::assertSame($filePath, $dependencies[0]->context->fileOccurrence->filepath);
@@ -42,7 +44,7 @@ final class AnonymousClassExtractorTest extends TestCase
         self::assertSame('anonymous_class_extends', $dependencies[0]->context->dependencyType->value);
 
         self::assertSame(
-            'Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures\InterfaceC',
+            InterfaceC::class,
             $dependencies[1]->token->toString()
         );
         self::assertSame($filePath, $dependencies[1]->context->fileOccurrence->filepath);

--- a/tests/Core/Ast/Parser/ClassConstantExtractorTest.php
+++ b/tests/Core/Ast/Parser/ClassConstantExtractorTest.php
@@ -14,6 +14,7 @@ use Deptrac\Deptrac\DefaultBehavior\Ast\Parser\PhpStanParser;
 use PhpParser\ParserFactory;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures\ClassA;
 
 final class ClassConstantExtractorTest extends TestCase
 {
@@ -32,7 +33,7 @@ final class ClassConstantExtractorTest extends TestCase
 
         $dependencies = $astClassReferences[1]->dependencies;
         self::assertSame(
-            'Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures\ClassA',
+            ClassA::class,
             $dependencies[0]->token->toString()
         );
         self::assertSame($filePath, $dependencies[0]->context->fileOccurrence->filepath);

--- a/tests/Core/Ast/Parser/ClassDocBlockExtractorTest.php
+++ b/tests/Core/Ast/Parser/ClassDocBlockExtractorTest.php
@@ -15,15 +15,18 @@ use Deptrac\Deptrac\DefaultBehavior\Ast\Parser\PhpStanParser;
 use PhpParser\ParserFactory;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures\ClassDocBlockDependencyBrother;
+use Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures\ClassDocBlockDependencyChild;
+use Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures\ClassDocBlockDependencySister;
 
 final class ClassDocBlockExtractorTest extends TestCase
 {
     private const EXPECTED = [
-        ['Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures\ClassDocBlockDependencySister', DependencyType::PARAMETER],
-        ['Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures\ClassDocBlockDependencyBrother', DependencyType::RETURN_TYPE],
-        ['Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures\ClassDocBlockDependencyChild', DependencyType::VARIABLE],
-        ['Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures\ClassDocBlockDependencySister', DependencyType::VARIABLE],
-        ['Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures\ClassDocBlockDependencyBrother', DependencyType::VARIABLE],
+        [ClassDocBlockDependencySister::class, DependencyType::PARAMETER],
+        [ClassDocBlockDependencyBrother::class, DependencyType::RETURN_TYPE],
+        [ClassDocBlockDependencyChild::class, DependencyType::VARIABLE],
+        [ClassDocBlockDependencySister::class, DependencyType::VARIABLE],
+        [ClassDocBlockDependencyBrother::class, DependencyType::VARIABLE],
     ];
 
     #[DataProvider('createParser')]

--- a/tests/Core/Ast/Parser/ClassExtractorTest.php
+++ b/tests/Core/Ast/Parser/ClassExtractorTest.php
@@ -17,6 +17,8 @@ use Deptrac\Deptrac\DefaultBehavior\Ast\Parser\PhpStanParser;
 use PhpParser\ParserFactory;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures\ClassAttribute;
+use Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures\ClassB;
 
 final class ClassExtractorTest extends TestCase
 {
@@ -33,12 +35,12 @@ final class ClassExtractorTest extends TestCase
 
         $dependencies = $astClassReferences[1]->dependencies;
         self::assertSame(
-            'Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures\ClassAttribute',
+            ClassAttribute::class,
             $dependencies[0]->token->toString()
         );
         self::assertSame(DependencyType::ATTRIBUTE, $dependencies[0]->context->dependencyType);
         self::assertSame(
-            'Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures\ClassB',
+            ClassB::class,
             $dependencies[1]->token->toString()
         );
         self::assertSame(DependencyType::VARIABLE, $dependencies[1]->context->dependencyType);

--- a/tests/Core/Ast/Parser/FunctionLikeExtractorTest.php
+++ b/tests/Core/Ast/Parser/FunctionLikeExtractorTest.php
@@ -67,9 +67,7 @@ final class FunctionLikeExtractorTest extends TestCase
         }
 
         return array_map(
-            static function (DependencyToken $dependency) {
-                return "{$dependency->token->toString()}::{$dependency->context->fileOccurrence->line} ({$dependency->context->dependencyType->value})";
-            },
+            static fn (DependencyToken $dependency) => "{$dependency->token->toString()}::{$dependency->context->fileOccurrence->line} ({$dependency->context->dependencyType->value})",
             $classReference->dependencies
         );
     }

--- a/tests/Core/Ast/Parser/ParserTest.php
+++ b/tests/Core/Ast/Parser/ParserTest.php
@@ -103,7 +103,7 @@ final class ParserTest extends TestCase
         $refsByName = [];
 
         foreach ($refs as $ref) {
-            $name = preg_replace('/^.*\\\\(\w+(\(\))?)$/', '$1', $ref->getToken()->toString());
+            $name = preg_replace('/^.*\\\\(\w+(\(\))?)$/', '$1', (string) $ref->getToken()->toString());
             $refsByName[$name] = $ref;
         }
 

--- a/tests/Core/Ast/Parser/TypeResolverTest.php
+++ b/tests/Core/Ast/Parser/TypeResolverTest.php
@@ -21,8 +21,6 @@ final class TypeResolverTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         if (class_exists(ParserConfig::class)) {
             $config = new ParserConfig(usedAttributes: ['lines' => true, 'indexes' => true]);
             $this->lexer = new Lexer($config);

--- a/tests/Core/Dependency/DependencyResolverTest.php
+++ b/tests/Core/Dependency/DependencyResolverTest.php
@@ -38,8 +38,6 @@ final class DependencyResolverTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
 
         $this->container = new ContainerBuilder();
@@ -169,9 +167,7 @@ final class DependencyResolverTest extends TestCase
 
         $inheritDeps = array_filter(
             $dependencyResult->getDependenciesAndInheritDependencies(),
-            static function ($v) {
-                return $v instanceof InheritDependency;
-            }
+            static fn ($v) => $v instanceof InheritDependency
         );
 
         self::assertCount(2, $inheritDeps);

--- a/tests/Core/Dependency/Emitter/EmitterTrait.php
+++ b/tests/Core/Dependency/Emitter/EmitterTrait.php
@@ -62,13 +62,11 @@ trait EmitterTrait
         $emitter->applyDependencies($astMap, $result);
 
         return array_map(
-            static function (DependencyInterface $d) {
-                return sprintf('%s:%d on %s',
-                    $d->getDepender()->toString(),
-                    $d->getContext()->fileOccurrence->line,
-                    $d->getDependent()->toString()
-                );
-            },
+            static fn (DependencyInterface $d) => sprintf('%s:%d on %s',
+                $d->getDepender()->toString(),
+                $d->getContext()->fileOccurrence->line,
+                $d->getDependent()->toString()
+            ),
             $result->getDependenciesAndInheritDependencies()
         );
     }

--- a/tests/Core/Dependency/TokenResolverTest.php
+++ b/tests/Core/Dependency/TokenResolverTest.php
@@ -22,8 +22,6 @@ final class TokenResolverTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->resolver = new TokenResolver();
     }
 

--- a/tests/Core/InputCollector/FileInputCollectorTest.php
+++ b/tests/Core/InputCollector/FileInputCollectorTest.php
@@ -18,9 +18,7 @@ final class FileInputCollectorTest extends TestCase
     {
         $collector = new FileInputCollector([__DIR__.'/Fixtures'], [], sys_get_temp_dir());
 
-        $files = array_map(static function ($filePath) {
-            return Path::normalize($filePath);
-        }, $collector->collect());
+        $files = array_map(Path::normalize(...), $collector->collect());
 
         natcasesort($files);
 
@@ -34,9 +32,7 @@ final class FileInputCollectorTest extends TestCase
     {
         $collector = new FileInputCollector(['Fixtures'], [], __DIR__);
 
-        $files = array_map(static function ($filePath) {
-            return Path::normalize($filePath);
-        }, $collector->collect());
+        $files = array_map(Path::normalize(...), $collector->collect());
 
         natcasesort($files);
 

--- a/tests/Core/InputCollector/PathNameFilterIteratorTest.php
+++ b/tests/Core/InputCollector/PathNameFilterIteratorTest.php
@@ -21,10 +21,9 @@ final class PathNameFilterIteratorTest extends TestCase
         $iterator = new PathNameFilterIterator($inner, $matchPatterns, $noMatchPatterns);
 
         $values = array_map(
-            static function (SplFileInfo $fileInfo) {
-                // replace the DIRECTORY_SEPARATOR with / to match with the expected result
-                return str_replace(DIRECTORY_SEPARATOR, '/', $fileInfo->getPathname());
-            },
+            // replace the DIRECTORY_SEPARATOR with / to match with the expected result
+
+            static fn (SplFileInfo $fileInfo) => str_replace(DIRECTORY_SEPARATOR, '/', $fileInfo->getPathname()),
             iterator_to_array($iterator, false)
         );
 

--- a/tests/Core/Layer/Collector/AttributeCollectorTest.php
+++ b/tests/Core/Layer/Collector/AttributeCollectorTest.php
@@ -22,8 +22,6 @@ final class AttributeCollectorTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->collector = new AttributeCollector();
     }
 

--- a/tests/Core/Layer/Collector/BoolCollectorTest.php
+++ b/tests/Core/Layer/Collector/BoolCollectorTest.php
@@ -20,8 +20,6 @@ final class BoolCollectorTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $collector = $this->createMock(CollectorInterface::class);
         $collector
             ->method('satisfy')

--- a/tests/Core/Layer/Collector/ClassCollectorTest.php
+++ b/tests/Core/Layer/Collector/ClassCollectorTest.php
@@ -9,6 +9,7 @@ use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeToken;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeType;
 use Deptrac\Deptrac\Contract\Layer\InvalidCollectorDefinitionException;
 use Deptrac\Deptrac\DefaultBehavior\Layer\ClassCollector;
+use Foo\Bar;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -23,7 +24,7 @@ final class ClassCollectorTest extends TestCase
 
     public static function dataProviderSatisfy(): iterable
     {
-        yield [['value' => '^Foo\\\\Bar$'], 'Foo\\Bar', true];
+        yield [['value' => '^Foo\\\\Bar$'], Bar::class, true];
         yield [['value' => '^Foo\\\\Bar$'], 'Foo\\Baz', false];
     }
 
@@ -51,7 +52,7 @@ final class ClassCollectorTest extends TestCase
     {
         $stat = $this->sut->satisfy(
             ['value' => '^Foo\\\\Bar$'],
-            new ClassLikeReference(ClassLikeToken::fromFQCN('Foo\\Bar'), $classLikeType),
+            new ClassLikeReference(ClassLikeToken::fromFQCN(Bar::class), $classLikeType),
         );
 
         self::assertSame($matches, $stat);

--- a/tests/Core/Layer/Collector/ClassLikeCollectorTest.php
+++ b/tests/Core/Layer/Collector/ClassLikeCollectorTest.php
@@ -9,6 +9,7 @@ use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeToken;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeType;
 use Deptrac\Deptrac\Contract\Layer\InvalidCollectorDefinitionException;
 use Deptrac\Deptrac\DefaultBehavior\Layer\ClassLikeCollector;
+use Foo\Bar;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -23,7 +24,7 @@ final class ClassLikeCollectorTest extends TestCase
 
     public static function dataProviderSatisfy(): iterable
     {
-        yield [['value' => '^Foo\\\\Bar$'], 'Foo\\Bar', true];
+        yield [['value' => '^Foo\\\\Bar$'], Bar::class, true];
         yield [['value' => '^Foo\\\\Bar$'], 'Foo\\Baz', false];
     }
 
@@ -51,7 +52,7 @@ final class ClassLikeCollectorTest extends TestCase
     {
         $stat = $this->sut->satisfy(
             ['value' => '^Foo\\\\Bar$'],
-            new ClassLikeReference(ClassLikeToken::fromFQCN('Foo\\Bar'), $classLikeType),
+            new ClassLikeReference(ClassLikeToken::fromFQCN(Bar::class), $classLikeType),
         );
 
         self::assertSame($matches, $stat);

--- a/tests/Core/Layer/Collector/ClassNameRegexCollectorTest.php
+++ b/tests/Core/Layer/Collector/ClassNameRegexCollectorTest.php
@@ -10,6 +10,7 @@ use Deptrac\Deptrac\Contract\Ast\AstMap\SuperGlobalToken;
 use Deptrac\Deptrac\Contract\Ast\AstMap\VariableReference;
 use Deptrac\Deptrac\Contract\Layer\InvalidCollectorDefinitionException;
 use Deptrac\Deptrac\DefaultBehavior\Layer\ClassNameRegexCollector;
+use Foo\Bar;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -19,14 +20,12 @@ final class ClassNameRegexCollectorTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->collector = new ClassNameRegexCollector();
     }
 
     public static function dataProviderSatisfy(): iterable
     {
-        yield [['value' => '/^Foo\\\\Bar$/i'], 'Foo\\Bar', true];
+        yield [['value' => '/^Foo\\\\Bar$/i'], Bar::class, true];
         yield [['value' => '/^Foo\\\\Bar$/i'], 'Foo\\Baz', false];
     }
 

--- a/tests/Core/Layer/Collector/ComposerCollectorTest.php
+++ b/tests/Core/Layer/Collector/ComposerCollectorTest.php
@@ -9,6 +9,7 @@ use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeToken;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeType;
 use Deptrac\Deptrac\Contract\Layer\InvalidCollectorDefinitionException;
 use Deptrac\Deptrac\DefaultBehavior\Layer\ComposerCollector;
+use PHPStan\PhpDocParser\Ast\Attribute;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -29,7 +30,7 @@ final class ComposerCollectorTest extends TestCase
                 'composerLockPath' => __DIR__.DIRECTORY_SEPARATOR.'data/composer.lock',
                 'packages' => ['phpstan/phpdoc-parser'],
             ],
-            'PHPStan\\PhpDocParser\\Ast\\Attribute',
+            Attribute::class,
             true,
         ];
         yield [

--- a/tests/Core/Layer/Collector/DirectoryCollectorTest.php
+++ b/tests/Core/Layer/Collector/DirectoryCollectorTest.php
@@ -16,8 +16,6 @@ final class DirectoryCollectorTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->collector = new DirectoryCollector();
     }
 

--- a/tests/Core/Layer/Collector/FunctionNameCollectorTest.php
+++ b/tests/Core/Layer/Collector/FunctionNameCollectorTest.php
@@ -19,8 +19,6 @@ final class FunctionNameCollectorTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->collector = new FunctionNameCollector();
     }
 

--- a/tests/Core/Layer/Collector/GlobCollectorTest.php
+++ b/tests/Core/Layer/Collector/GlobCollectorTest.php
@@ -16,8 +16,6 @@ final class GlobCollectorTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->collector = new GlobCollector(__DIR__);
     }
 

--- a/tests/Core/Layer/Collector/InterfaceCollectorTest.php
+++ b/tests/Core/Layer/Collector/InterfaceCollectorTest.php
@@ -9,6 +9,7 @@ use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeToken;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeType;
 use Deptrac\Deptrac\Contract\Layer\InvalidCollectorDefinitionException;
 use Deptrac\Deptrac\DefaultBehavior\Layer\InterfaceCollector;
+use Foo\Bar;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -23,7 +24,7 @@ final class InterfaceCollectorTest extends TestCase
 
     public static function dataProviderSatisfy(): iterable
     {
-        yield [['value' => '^Foo\\\\Bar$'], 'Foo\\Bar', true];
+        yield [['value' => '^Foo\\\\Bar$'], Bar::class, true];
         yield [['value' => '^Foo\\\\Bar$'], 'Foo\\Baz', false];
     }
 
@@ -51,7 +52,7 @@ final class InterfaceCollectorTest extends TestCase
     {
         $stat = $this->sut->satisfy(
             ['value' => '^Foo\\\\Bar$'],
-            new ClassLikeReference(ClassLikeToken::fromFQCN('Foo\\Bar'), $classLikeType),
+            new ClassLikeReference(ClassLikeToken::fromFQCN(Bar::class), $classLikeType),
         );
 
         self::assertSame($matches, $stat);

--- a/tests/Core/Layer/Collector/LayerCollectorTest.php
+++ b/tests/Core/Layer/Collector/LayerCollectorTest.php
@@ -19,8 +19,6 @@ final class LayerCollectorTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->resolver = $this->createMock(LayerResolverInterface::class);
 
         $this->collector = new LayerCollector($this->resolver);
@@ -66,9 +64,7 @@ final class LayerCollectorTest extends TestCase
         $this->resolver
             ->method('isReferenceInLayer')
             ->with('FooLayer', $reference)
-            ->willReturnCallback(function (string $layerName, ClassLikeReference $reference) {
-                return $this->collector->satisfy(['value' => 'FooLayer'], $reference);
-            })
+            ->willReturnCallback(fn (string $layerName, ClassLikeReference $reference) => $this->collector->satisfy(['value' => 'FooLayer'], $reference))
         ;
 
         $this->expectException(InvalidLayerDefinitionException::class);

--- a/tests/Core/Layer/Collector/MethodCollectorTest.php
+++ b/tests/Core/Layer/Collector/MethodCollectorTest.php
@@ -21,8 +21,6 @@ final class MethodCollectorTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->astParser = $this->createMock(NikicPhpParser::class);
 
         $this->collector = new MethodCollector($this->astParser);

--- a/tests/Core/Layer/Collector/SuperglobalCollectorTest.php
+++ b/tests/Core/Layer/Collector/SuperglobalCollectorTest.php
@@ -19,8 +19,6 @@ final class SuperglobalCollectorTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->collector = new SuperglobalCollector();
     }
 

--- a/tests/Core/Layer/Collector/TagValueRegexCollectorTest.php
+++ b/tests/Core/Layer/Collector/TagValueRegexCollectorTest.php
@@ -21,8 +21,6 @@ final class TagValueRegexCollectorTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->collector = new TagValueRegexCollector();
     }
 

--- a/tests/Core/Layer/Collector/TraitCollectorTest.php
+++ b/tests/Core/Layer/Collector/TraitCollectorTest.php
@@ -9,6 +9,7 @@ use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeToken;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeType;
 use Deptrac\Deptrac\Contract\Layer\InvalidCollectorDefinitionException;
 use Deptrac\Deptrac\DefaultBehavior\Layer\TraitCollector;
+use Foo\Bar;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -23,7 +24,7 @@ final class TraitCollectorTest extends TestCase
 
     public static function dataProviderSatisfy(): iterable
     {
-        yield [['value' => '^Foo\\\\Bar$'], 'Foo\\Bar', true];
+        yield [['value' => '^Foo\\\\Bar$'], Bar::class, true];
         yield [['value' => '^Foo\\\\Bar$'], 'Foo\\Baz', false];
     }
 
@@ -51,7 +52,7 @@ final class TraitCollectorTest extends TestCase
     {
         $stat = $this->sut->satisfy(
             ['value' => '^Foo\\\\Bar$'],
-            new ClassLikeReference(ClassLikeToken::fromFQCN('Foo\\Bar'), $classLikeType),
+            new ClassLikeReference(ClassLikeToken::fromFQCN(Bar::class), $classLikeType),
         );
 
         self::assertSame($matches, $stat);

--- a/tests/Supportive/Console/Command/AnalyseCommandTest.php
+++ b/tests/Supportive/Console/Command/AnalyseCommandTest.php
@@ -13,7 +13,6 @@ class AnalyseCommandTest extends TestCase
     protected function setUp(): void
     {
         putenv('GITHUB_ACTIONS=true');
-        parent::setUp();
     }
 
     public function testDefaultFormatterForGithubActions(): void

--- a/tests/Supportive/Console/EnvTest.php
+++ b/tests/Supportive/Console/EnvTest.php
@@ -13,7 +13,6 @@ class EnvTest extends TestCase
     {
         putenv('TEST=test');
         putenv('FOO=true');
-        parent::setUp();
     }
 
     public function testEnvPresent(): void

--- a/tests/Supportive/DependencyInjection/DeptracExtensionTest.php
+++ b/tests/Supportive/DependencyInjection/DeptracExtensionTest.php
@@ -51,8 +51,6 @@ final class DeptracExtensionTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->container = new ContainerBuilder();
         $this->extension = new DeptracExtension();
     }

--- a/tests/Supportive/File/DumperTest.php
+++ b/tests/Supportive/File/DumperTest.php
@@ -29,16 +29,12 @@ final class DumperTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->sourceFile = __DIR__.'/Fixtures/deptrac.yaml';
         $this->dumper = new Dumper($this->sourceFile);
     }
 
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         unset($this->dumper);
     }
 

--- a/tests/Supportive/OutputFormatter/ConsoleOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/ConsoleOutputFormatterTest.php
@@ -23,6 +23,7 @@ use Deptrac\Deptrac\DefaultBehavior\Dependency\Helpers\Dependency;
 use Deptrac\Deptrac\DefaultBehavior\OutputFormatter\ConsoleOutputFormatter;
 use Deptrac\Deptrac\Supportive\Console\Symfony\Style;
 use Deptrac\Deptrac\Supportive\Console\Symfony\SymfonyOutput;
+use Foo\Bar;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
@@ -226,7 +227,7 @@ final class ConsoleOutputFormatterTest extends TestCase
         yield 'an warning occurred' => [
             [],
             [],
-            'warnings' => [Warning::tokenIsInMoreThanOneLayer(ClassLikeToken::fromFQCN('Foo\Bar')->toString(), ['Layer 1', 'Layer 2'])],
+            'warnings' => [Warning::tokenIsInMoreThanOneLayer(ClassLikeToken::fromFQCN(Bar::class)->toString(), ['Layer 1', 'Layer 2'])],
             '[WARNING]Foo\Barisinmorethanonelayer["Layer1","Layer2"].Itisrecommendedthatonetokenshouldonlybeinonelayer.Report:Violations:0Skippedviolations:0Uncovered:0Allowed:0Warnings:1Errors:0',
         ];
     }

--- a/tests/Supportive/OutputFormatter/FormatterProviderTest.php
+++ b/tests/Supportive/OutputFormatter/FormatterProviderTest.php
@@ -18,8 +18,8 @@ final class FormatterProviderTest extends TestCase
     public function testGet(): void
     {
         $formatterProvider = new FormatterProvider(new ServiceLocator([
-            ConsoleOutputFormatter::getName() => static function () { return new ConsoleOutputFormatter(); },
-            TableOutputFormatter::getName() => static function () { return new TableOutputFormatter(); },
+            ConsoleOutputFormatter::getName() => static fn () => new ConsoleOutputFormatter(),
+            TableOutputFormatter::getName() => static fn () => new TableOutputFormatter(),
         ]));
 
         self::assertTrue($formatterProvider->has(ConsoleOutputFormatter::getName()));

--- a/tests/Supportive/OutputFormatter/GithubActionsOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/GithubActionsOutputFormatterTest.php
@@ -23,6 +23,7 @@ use Deptrac\Deptrac\DefaultBehavior\Dependency\Helpers\Dependency;
 use Deptrac\Deptrac\DefaultBehavior\OutputFormatter\GithubActionsOutputFormatter;
 use Deptrac\Deptrac\Supportive\Console\Symfony\Style;
 use Deptrac\Deptrac\Supportive\Console\Symfony\SymfonyOutput;
+use Foo\Bar;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
@@ -172,7 +173,7 @@ final class GithubActionsOutputFormatterTest extends TestCase
             'rules' => [],
             'errors' => [],
             'warnings' => [
-                Warning::tokenIsInMoreThanOneLayer(ClassLikeToken::fromFQCN('Foo\Bar')->toString(), ['Layer 1', 'Layer 2']),
+                Warning::tokenIsInMoreThanOneLayer(ClassLikeToken::fromFQCN(Bar::class)->toString(), ['Layer 1', 'Layer 2']),
             ],
             "::warning ::Foo\Bar is in more than one layer [\"Layer 1\", \"Layer 2\"]. It is recommended that one token should only be in one layer.".PHP_EOL,
         ];

--- a/tests/Supportive/OutputFormatter/JUnitOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/JUnitOutputFormatterTest.php
@@ -242,13 +242,13 @@ final class JUnitOutputFormatterTest extends TestCase
         self::assertTrue($loaded);
 
         self::assertTrue($reader->schemaValidate(__DIR__.'/data/junit-schema-ant.xsd'),
-            implode(array_map(static fn ($e) => $e->line.': '.$e->message, libxml_get_errors())));
+            implode('', array_map(static fn ($e) => $e->line.': '.$e->message, libxml_get_errors())));
         self::assertTrue($reader->schemaValidate(__DIR__.'/data/junit-schema-jenkins.xsd'),
-            implode(array_map(static fn ($e) => $e->message, libxml_get_errors())));
+            implode('', array_map(static fn ($e) => $e->message, libxml_get_errors())));
         self::assertTrue($reader->schemaValidate(__DIR__.'/data/junit-schema-llg.xsd'),
-            implode(array_map(static fn ($e) => $e->message, libxml_get_errors())));
+            implode('', array_map(static fn ($e) => $e->message, libxml_get_errors())));
         self::assertTrue($reader->schemaValidate(__DIR__.'/data/junit-schema-maven.xsd'),
-            implode(array_map(static fn ($e) => $e->message, libxml_get_errors())));
+            implode('', array_map(static fn ($e) => $e->message, libxml_get_errors())));
 
         self::assertXmlFileEqualsXmlFile(
             __DIR__.'/data/'.self::$actual_junit_report_file,

--- a/tests/Supportive/OutputFormatter/TableOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/TableOutputFormatterTest.php
@@ -23,6 +23,7 @@ use Deptrac\Deptrac\DefaultBehavior\Dependency\Helpers\Dependency;
 use Deptrac\Deptrac\DefaultBehavior\OutputFormatter\TableOutputFormatter;
 use Deptrac\Deptrac\Supportive\Console\Symfony\Style;
 use Deptrac\Deptrac\Supportive\Console\Symfony\SymfonyOutput;
+use Foo\Bar;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
@@ -306,7 +307,7 @@ class TableOutputFormatterTest extends TestCase
         yield 'an warning occurred' => [
             'rules' => [],
             'errors' => [],
-            'warnings' => [Warning::tokenIsInMoreThanOneLayer(ClassLikeToken::fromFQCN('Foo\Bar')->toString(), ['Layer 1', 'Layer 2'])],
+            'warnings' => [Warning::tokenIsInMoreThanOneLayer(ClassLikeToken::fromFQCN(Bar::class)->toString(), ['Layer 1', 'Layer 2'])],
             ' ------------------------------------------------------------------------------------------------------------------------- 
   Warnings                                                                                                                 
  ------------------------------------------------------------------------------------------------------------------------- 


### PR DESCRIPTION
- Add Rector tool to Makefile with rector and rector-check targets
- Enable PHP 8.1 prepared set in rector.php
- Update tests to use ::class constants instead of FQCN strings
- Prefer arrow functions and first-class callables (e.g. strval(...), Path::normalize(...)) for array_map and callbacks
- Remove redundant parent::setUp/tearDown calls in tests
- Add explicit (string) casts where needed and tweak JUnit formatter tests to use correct implode glue

This aligns the project with PHP 8.1, improves readability, and prepares codebase for automated refactoring with Rector.