### PR TITLE
Allow layer references in layer collectors

### DIFF
--- a/docs/blog/2023-05-11_PHP_configuration.md
+++ b/docs/blog/2023-05-11_PHP_configuration.md
@@ -79,6 +79,19 @@ Notice that we assign all the layer configs to a variable. This is important to 
         );
 ```
 
+A layer collector can also reference a previously defined layer variable, while
+string layer names remain available when declaration order makes a variable
+reference impractical:
+
+```php
+    $config
+        ->layers(
+            Layer::withName('AllDependencies')->collectors(
+                LayerConfig::create($dependency),
+            ),
+        );
+```
+
 You can also define configuration for the formatters if you need to, again re-using the previously defined layers to ensure you don't have a typo in your definition:
 
 ```php

--- a/src/Contract/Config/Collector/LayerConfig.php
+++ b/src/Contract/Config/Collector/LayerConfig.php
@@ -4,8 +4,17 @@ namespace Deptrac\Deptrac\Contract\Config\Collector;
 
 use Deptrac\Deptrac\Contract\Config\CollectorType;
 use Deptrac\Deptrac\Contract\Config\ConfigurableCollectorConfig;
+use Deptrac\Deptrac\Contract\Config\Layer;
 
 final class LayerConfig extends ConfigurableCollectorConfig
 {
     protected CollectorType $collectorType = CollectorType::TYPE_LAYER;
+
+    public static function create(string|Layer $config): self
+    {
+        /** @var self $layerConfig parent::create() instantiates new static() */
+        $layerConfig = parent::create($config instanceof Layer ? $config->name : $config);
+
+        return $layerConfig;
+    }
 }

--- a/tests/Contract/Config/LayerConfigTest.php
+++ b/tests/Contract/Config/LayerConfigTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Deptrac\Deptrac\Contract\Config;
+
+use Deptrac\Deptrac\Contract\Config\Collector\LayerConfig;
+use Deptrac\Deptrac\Contract\Config\Layer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class LayerConfigTest extends TestCase
+{
+    public static function provideLayerReference(): iterable
+    {
+        yield 'layer name' => ['Shared'];
+        yield 'layer object' => [Layer::withName('Shared')];
+    }
+
+    #[DataProvider('provideLayerReference')]
+    public function testCreateFromLayerReference(string|Layer $layer): void
+    {
+        self::assertSame(
+            [
+                'value' => 'Shared',
+                'type' => 'layer',
+                'private' => false,
+            ],
+            LayerConfig::create($layer)->toArray(),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- allow `LayerConfig::create()` to accept either a layer name or a `Layer` object
- preserve the existing string form and serialize layer objects by name
- document variable references and cover both forms with a focused contract test

Fixes #1196.

## Testing

- focused PHPUnit: 2 tests, 2 assertions
- compatible PHPUnit suite: 407 tests, 1,018 assertions
- PHPStan
- PHP CS Fixer (sequential): 0 of 369 files need changes
- Composer dependency analyser and Deptrac self-analysis
- E2E fixture and strict MkDocs build
- focused Infection: 3/3 mutants killed, 100% MSI

The complete local suite on PHP 8.5 has two pre-existing `ConsoleSubscriberTest` failures because Stopwatch renders `0 sec.` while the assertions expect a decimal duration. The project CI matrix runs PHP 8.2–8.4.
