### PR TITLE
docs: use vendor/bin/deptrac as default usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,5 @@ See the [contribution guide](docs/CONTRIBUTING.md).
 * [Debugging](docs/debugging.md) - Overview of the debug commands
 * [Code Of Conduct](docs/CODE_OF_CONDUCT.md) - Our community standards
 * [Contribute](docs/CONTRIBUTING.md) - Advice for contributing code changes,
-  e.g. how to run tests or how to build a phar file with your changes that you
-  can use to analyse your projects
+  e.g. how to run tests or how to use your local changes to analyse your projects
 * [Security Guide](docs/SECURITY.md) - How to report security vulnerabilities

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Any merge request must pass our build pipeline which consists of the following:
 * Unit Tests for all supported PHP-versions
 * Check for coding guidelines
 * Static code analysis with phpstan and psalm
-* End 2 End-tests, ensuring `deptrac.phar` can be built
+* A basic End 2 End-test, ensuring `deptrac` runs against a fixture config
 
 You can use the provided Makefile to execute these steps locally. The `make`
 command is supported by most major operating systems, but you might need to
@@ -100,16 +100,18 @@ We also run a tool called infection for mutation testing:
 make infection
 ```
 
-### Build Deptrac
+### Running your local Deptrac
 
-You can build the `deptrac.phar` both to ensure it works, as well as for using
-it to analyse your existing projects to see if your changes work as expected.
+You can run Deptrac directly from the repository to verify your changes work as
+expected. The `deptrac` binary in the project root uses your local source code:
 
 ```console
-$ make build
+$ ./deptrac analyse
 ```
 
-This will create an executable file `deptrac.phar` in the current directory.
+To try your changes against another project, install your local checkout via a
+Composer [path repository](https://getcomposer.org/doc/05-repositories.md#path)
+and run it with `vendor/bin/deptrac`.
 
 ## Deptrac Engine (Internals)
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -85,7 +85,7 @@ configuration:
 installed on your system)
 
 ```console
-$ php deptrac.phar analyse --config-file=examples/ModelController1.depfile.yaml
+$ vendor/bin/deptrac analyse --config-file=examples/ModelController1.depfile.yaml
 ```
 
 After Deptrac has finished, an image should be opened:
@@ -258,7 +258,7 @@ class SomeController
 After running Deptrac for this example
 
 ```console
-$ php deptrac.phar analyse --config-file=examples/ModelController2.depfile.yaml
+$ vendor/bin/deptrac analyse --config-file=examples/ModelController2.depfile.yaml
 ```
 
 we will get this output:
@@ -310,7 +310,7 @@ values (`Core\CoreClass`) are dependency tokens.
 Matched violations will be marked as skipped:
 
 ```console
-$ php deptrac.phar analyse --config-file=examples/SkipViolations.yaml --report-skipped
+$ vendor/bin/deptrac analyse --config-file=examples/SkipViolations.yaml --report-skipped
 1/1 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
 
 [SKIPPED] Library\LibClass must not depend on Core\CoreClass (Library on Core)

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -10,7 +10,7 @@ With the `debug:layer`-command you can list all tokens which are matched in
 a specific layer. This command only shows tokens that would be emitted by your analyser configuration.
 
 ```console
-$ php deptrac.phar debug:layer --config-file=deptrac.config.php Time
+$ vendor/bin/deptrac debug:layer --config-file=deptrac.config.php Time
 
  ---------------------------------------------------- ------------
   Time                                                 Token Type
@@ -31,7 +31,7 @@ $ php deptrac.phar debug:layer --config-file=deptrac.config.php Time
 The `debug:token` (previously `debug:class-like`)-command will let you know which layers a specified token belongs to. Since you can specify the token type, this commands ignores your analyser configuration for emitted token types.
 
 ```console
-$ php deptrac.phar debug:token --config-file=examples/DirectoryLayer.depfile.yaml 'examples\Layer1\AnotherClassLikeAController' class-like
+$ vendor/bin/deptrac debug:token --config-file=examples/DirectoryLayer.depfile.yaml 'examples\Layer1\AnotherClassLikeAController' class-like
 
 Controller
 Layer1
@@ -44,7 +44,7 @@ not assigned to any layer. This is useful to test that your collector
 configuration for layers is correct.  This command only shows tokens that would be emitted by your analyser configuration.
 
 ```console
-$ php deptrac.phar debug:unassigned --config-file=examples/DirectoryLayer.depfile.yaml
+$ vendor/bin/deptrac debug:unassigned --config-file=examples/DirectoryLayer.depfile.yaml
 
 examples\Layer1\AnotherClassLikeAController
 examples\Layer1\SomeClass
@@ -60,7 +60,7 @@ pipelines.
 With the `debug:dependencies`-command you can see all dependencies of your layer. You can optionally specify a target layer to get only dependencies from one layer to the other:
 
 ```console
-$ php deptrac.phar debug:dependencies debug:dependencies Ast InputCollector
+$ vendor/bin/deptrac debug:dependencies debug:dependencies Ast InputCollector
 
   Deptrac\Deptrac\Core\Ast\AstMapExtractor depends on Deptrac\Deptrac\Core\InputCollector\InputCollectorInterface (InputCollector)
   .../deptrac/src/Core/Ast/AstMapExtractor.php:15
@@ -78,7 +78,7 @@ You can optionally specify a limit (`--limit=<int>`) of how many times can be th
 if you want to find dependencies that are barely used and may be a prime candidate to get rid of.
 
 ```console
-$ php deptrac.phar debug:unused --limit=10
+$ vendor/bin/deptrac debug:unused --limit=10
 
   Analyser layer is dependent Layer layer 5 times
   Ast layer is dependent File layer 9 times
@@ -100,7 +100,7 @@ This command list the layers corresponding to the passed files. Optionally it
 can also list all the layers that depend on those layers.
 
 ```console
-$ php deptrac.phar changed-files --with-dependencies src/Supportive/File/FileReader.php
+$ vendor/bin/deptrac changed-files --with-dependencies src/Supportive/File/FileReader.php
 
   File
   Console;Ast;InputCollector;Analyser;Dependency;Layer

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,55 +23,24 @@ You can analyse projects that require an older PHP version as long as
 
 ## Installation
 
-You can install Deptrac via Composer. We recommend using the [deptrac](https://github.com/deptrac/deptrac) package for this.
-Alternatively, you can also use [PHIVE](#phive) or download the
-[PHAR](#phar) attached to each release on GitHub.
-This will ensure that Deptrac and its dependencies are
-bundled together and will not interfere with any of your project's dependencies.
+You can install Deptrac via Composer using the
+[deptrac](https://github.com/deptrac/deptrac) package.
 
 ### Composer
 
 ```console
 $ composer require --dev deptrac/deptrac
-vendor/bin/deptrac analyse
 ```
 
-### PHAR
-
-Download the latest [deptrac.phar](https://github.com/deptrac/deptrac/releases).
-
-You can run the phar file using php:
+This installs the `deptrac` binary into your project's `vendor/bin` directory.
+You can then run it with:
 
 ```console
-$ php deptrac.phar analyse
+$ vendor/bin/deptrac analyse
 ```
 
-All examples in this documentation, assume you have the deptrac.phar downloaded
-in your project's root directory as described above.
-
-Feel free to add Deptrac to your PATH (i.e. `/usr/local/bin/deptrac`) to make it
-globally available.
-
-```console
-$ curl -LS https://github.com/deptrac/deptrac/releases/download/2.0.1/deptrac.phar -o deptrac.phar
-
-# optional
-$ sudo chmod +x deptrac.phar
-$ sudo mv deptrac.phar /usr/local/bin/deptrac
-```
-
-### PHIVE
-
-You can install Deptrac with [Phive](https://phar.io/#Install)
-
-`phive install -g deptrac/deptrac`
-
-and accept the key with fingerprint
-`57CB 556F 242F C8D4 FD48 3C2C 4743 6587 D82C 4A39`.
-
-To upgrade Deptrac use the following command:
-
-`phive update -g deptrac/deptrac`
+All examples in this documentation assume you run Deptrac via
+`vendor/bin/deptrac` as described above.
 
 ### Optional Dependency: Graphviz
 
@@ -102,7 +71,7 @@ name `deptrac.php` in your project's root directory.
 Deptrac can generate a template for you, using the `init` command.
 
 ```console
-$ php deptrac.phar init
+$ vendor/bin/deptrac init
 ```
 
 The main purpose of this file is:
@@ -171,17 +140,17 @@ You can learn more about the file in the [Configuration reference](configuration
 
 Once you have set up the config file you can run Deptrac to analyse your code
 and check for violations. If you use the default configuration file, you can
-type `php deptrac.phar`, otherwise you will need to specify which command and
+type `vendor/bin/deptrac`, otherwise you will need to specify which command and
 config file should be used.
 
 ```console
-$ php deptrac.phar
+$ vendor/bin/deptrac
 
 # which is equivalent to
-$ php deptrac.phar analyse --config-file=deptrac.php
+$ vendor/bin/deptrac analyse --config-file=deptrac.php
 ```
 
-If you run `php deptrac.phar -v` you'll get a more verbose output.
+If you run `vendor/bin/deptrac -v` you'll get a more verbose output.
 
 The analyse command runs with a caching mechanism for parsed files by default.
 This can be disabled with the `--no-cache` option.
@@ -273,6 +242,5 @@ Please don't be inconsiderate or mean, or anything in between.
 * [Debugging](debugging.md) - Overview of the debug commands
 * [Code Of Conduct](CODE_OF_CONDUCT.md) - Our community standards
 * [Contribute](CONTRIBUTING.md) - Advice for contributing code changes,
-  e.g. how to run tests or how to build a phar file with your changes that you
-  can use to analyse your projects
+  e.g. how to run tests or how to use your local changes to analyse your projects
 * [Security Guide](SECURITY.md) - How to report security vulnerabilities


### PR DESCRIPTION
Phars are no longer compiled, so document Composer's vendor/bin/deptrac as the default way to run Deptrac. Remove the PHAR and PHIVE install sections and replace all php deptrac.phar examples across the docs.