### PR TITLE
feat: opt-in method-level layer granularity

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -21,7 +21,7 @@ return static function (ContainerConfigurator $container): void {
 
     $services
         ->set(AstFileReferenceFileCache::class)
-        ->args(['%cache_file%', DeptracVersion::get()])
+        ->args(['%cache_file%', DeptracVersion::get(), '%method_granularity%'])
     ;
 
     $services->alias(AstFileReferenceDeferredCacheInterface::class, AstFileReferenceFileCache::class);

--- a/config/services.php
+++ b/config/services.php
@@ -50,6 +50,7 @@ use Deptrac\Deptrac\DefaultBehavior\Ast\Extractors\FunctionLikeExtractor;
 use Deptrac\Deptrac\DefaultBehavior\Ast\Extractors\GroupUseExtractor;
 use Deptrac\Deptrac\DefaultBehavior\Ast\Extractors\InstanceofExtractor;
 use Deptrac\Deptrac\DefaultBehavior\Ast\Extractors\InterfaceExtractor;
+use Deptrac\Deptrac\DefaultBehavior\Ast\Extractors\MethodCallExtractor;
 use Deptrac\Deptrac\DefaultBehavior\Ast\Extractors\NewExtractor;
 use Deptrac\Deptrac\DefaultBehavior\Ast\Extractors\PropertyExtractor;
 use Deptrac\Deptrac\DefaultBehavior\Ast\Extractors\StaticCallExtractor;
@@ -67,6 +68,7 @@ use Deptrac\Deptrac\DefaultBehavior\Dependency\FileDependencyEmitter;
 use Deptrac\Deptrac\DefaultBehavior\Dependency\FunctionCallDependencyEmitter;
 use Deptrac\Deptrac\DefaultBehavior\Dependency\FunctionDependencyEmitter;
 use Deptrac\Deptrac\DefaultBehavior\Dependency\FunctionSuperglobalDependencyEmitter;
+use Deptrac\Deptrac\DefaultBehavior\Dependency\MethodDependencyEmitter;
 use Deptrac\Deptrac\DefaultBehavior\Dependency\UsesDependencyEmitter;
 use Deptrac\Deptrac\DefaultBehavior\Layer\AttributeCollector;
 use Deptrac\Deptrac\DefaultBehavior\Layer\BoolCollector;
@@ -191,12 +193,14 @@ return static function (ContainerConfigurator $container): void {
         ->set(NikicPhpParser::class)
         ->args([
             '$extractors' => tagged_iterator('reference_extractors'),
+            '$methodGranularity' => param('method_granularity'),
         ])
     ;
     $services
         ->set(PhpStanParser::class)
         ->args([
             '$extractors' => tagged_iterator('reference_extractors'),
+            '$methodGranularity' => param('method_granularity'),
         ])
     ;
     $services
@@ -257,6 +261,11 @@ return static function (ContainerConfigurator $container): void {
         ->tag('reference_extractors')
     ;
     $services
+        ->set(MethodCallExtractor::class)
+        ->args(['$methodGranularity' => param('method_granularity')])
+        ->tag('reference_extractors')
+    ;
+    $services
         ->set(NewExtractor::class)
         ->tag('reference_extractors')
     ;
@@ -298,6 +307,7 @@ return static function (ContainerConfigurator $container): void {
     $services->set(TokenResolver::class);
     $services
         ->set(ClassDependencyEmitter::class)
+        ->args(['$config' => param('analyser')])
         ->tag('dependency_emitter', ['key' => EmitterType::CLASS_TOKEN->value])
     ;
     $services
@@ -319,6 +329,11 @@ return static function (ContainerConfigurator $container): void {
     $services
         ->set(FunctionSuperglobalDependencyEmitter::class)
         ->tag('dependency_emitter', ['key' => EmitterType::FUNCTION_SUPERGLOBAL_TOKEN->value])
+    ;
+    $services
+        ->set(MethodDependencyEmitter::class)
+        ->args(['$layerResolver' => service(LayerResolverInterface::class)])
+        ->tag('dependency_emitter', ['key' => EmitterType::METHOD_TOKEN->value])
     ;
     $services
         ->set(UsesDependencyEmitter::class)
@@ -492,7 +507,11 @@ return static function (ContainerConfigurator $container): void {
             '$config' => param('analyser'),
         ])
     ;
-    $services->set(LayerForTokenAnalyser::class);
+    $services->set(LayerForTokenAnalyser::class)
+        ->args([
+            '$methodGranularity' => param('method_granularity'),
+        ])
+    ;
     $services->set(UnassignedTokenAnalyser::class)
         ->args([
             '$config' => param('analyser'),

--- a/docs/collectors.md
+++ b/docs/collectors.md
@@ -292,6 +292,11 @@ deptrac:
 Every class having a method that matches the regular expression `.*foo`,
 e.g. `getFoo()` or `setFoo()` becomes a part of the *Foo services* layer.
 
+When used with `scope: method` (see
+[Method-level layers](#method-level-layers-collector-scope)), the collector
+matches the name of the individual method instead, and only that method — not
+its whole class — is assigned to the layer.
+
 ## `superglobal` Collector
 
 The `superglobal` collector allows collecting superglobal PHP variables matching
@@ -384,3 +389,94 @@ This means that tokens collected by this specific collector can be referenced on
 This can be useful at least in 2 cases:
  - **External library that should be used only by one particular layer** - In this case, you might via vendor include a library that should be used only by this particular layer and nobody else.
  - **Layer that has a public API and private implementation** - You might want to provide only a few classes to be available to use by other layers (public API) that call the internal implementation of the layer that on the other hand should not be available to anybody else other than the public API of the layer.
+
+## Method-level layers (collector scope)
+
+By default a collector assigns whole tokens (classes, functions, files) to a
+layer. With `scope: method` a collector instead matches individual **class
+methods**, so a single method can live in a different layer than its class.
+Everything declared inside such a method — parameter and return types,
+attributes, and the method body — then belongs to the method's layer instead of
+the class's layer. Methods that are not matched by any `scope: method` collector
+keep belonging to their class's layers, exactly as before.
+
+This enables architectures where one class mixes code from several layers, e.g.
+a vertical-slice "feature" class combining a route handler (infrastructure) with
+an event or command handler (application):
+
+```yaml
+deptrac:
+  paths:
+    - ./src
+  analyser:
+    types:
+      - class
+      - method
+  layers:
+    - name: Infrastructure
+      collectors:
+        - type: attribute
+          value: Symfony\Component\HttpKernel\Attribute\AsController
+    - name: Application
+      collectors:
+        - type: attribute
+          value: Symfony\Component\EventDispatcher\Attribute\AsEventListener
+          scope: method
+  ruleset:
+    Infrastructure:
+      - Application
+    Application: ~
+```
+
+```php
+#[AsController]
+class RegisterBookFeature          // class → Infrastructure
+{
+    public function registerBook(): void
+    {
+        $this->handleRegister();   // allowed: Infrastructure may depend on Application
+    }
+
+    #[AsEventListener]
+    public function handleRegister(): void   // method → Application
+    {
+        $this->registerBook();     // violation: Application must not depend on Infrastructure
+    }
+}
+```
+
+Notes:
+
+- Method-level analysis is **opt-in**: add `method` to `analyser.types`
+  (`AnalyserConfig::types(EmitterType::METHOD_TOKEN, ...)` in PHP config), or no
+  method-token dependencies are emitted. Calls like `$this->method()`,
+  `self::method()` and `static::method()` are tracked as dependencies on the
+  called method.
+- Method references are only extracted (and cached) when the config opts in —
+  either via the `method` analyser type or via any `scope: method` collector.
+  Projects without the opt-in keep the smaller AST and cache. Toggling the
+  opt-in invalidates the AST cache once, causing a full re-parse on the next
+  run.
+- A method matched by a `scope: method` collector **leaves** its class's layers;
+  a call to a method without a layer of its own is checked against its class's
+  layers.
+- `scope: method` works with any collector that understands method references:
+  `attribute` (method and parameter attributes), `method` (the method name),
+  `tagValueRegex` (method docblock tags), `directory` and `glob` (the file the
+  method is declared in), and `bool` (its `must`/`must_not` children are
+  evaluated against the method). In the PHP config DSL, call `->forMethods()` on
+  the collector config.
+- Inheritance: when a class extends (or uses, via traits) a class whose layered
+  methods have dependencies, those dependencies also count against the
+  inheriting **class** (as inherit dependencies), mirroring how class-level
+  dependencies are flattened.
+- With the PHPStan parser (`feature_flags: phpstan_parser: true`), cross-class
+  instance calls are also resolved to the target class's method when the
+  receiver's type is statically known from class context — typed properties
+  (`$this->service->method()`), new expressions (`(new Foo())->method()`) and
+  return-type chains (`Foo::create()->method()`).
+- Limitations: `parent::method()` calls, dynamic calls (`$this->$name()`) and
+  calls on `$this` inside methods of anonymous classes are not tracked at method
+  level; receivers typed only by local variables or parameters are not resolved;
+  cross-class static calls and, with the Nikic parser, all cross-class instance
+  calls are tracked at class level as before.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,8 @@ A list with at least one of the following supported dependency types:
 <li><strong>function_superglobal</strong> &mdash; analyses function definitions for superglobal usage.
 </li>
 <li><strong>function_call</strong> &mdash; analyses calls to custom(user-defined) functions
+</li>
+<li><strong>method</strong> &mdash; analyses dependencies declared inside class methods, attributing them to methods that are assigned to a layer of their own via a <code>scope: method</code> collector (see <a href="collectors.md#method-level-layers-collector-scope">Method-level layers</a>).
 
 </td>
 <td>

--- a/docs/examples/MethodGranularity.depfile.yaml
+++ b/docs/examples/MethodGranularity.depfile.yaml
@@ -1,0 +1,22 @@
+deptrac:
+  paths: ["./MethodGranularity/"]
+  analyser:
+    types:
+      - class
+      - method
+  layers:
+    - name: Infrastructure
+      collectors:
+        - type: attribute
+          value: AsController
+    - name: Application
+      collectors:
+        - type: attribute
+          value: AsEventListener
+          scope: method
+        - type: classNameRegex
+          value: /BookCommand$/
+  ruleset:
+    Infrastructure:
+      - Application
+    Application: ~

--- a/docs/examples/MethodGranularity/RegisterBookFeature.php
+++ b/docs/examples/MethodGranularity/RegisterBookFeature.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Examples\MethodGranularity;
+
+#[\Attribute]
+class AsController {}
+
+#[\Attribute]
+class AsEventListener {}
+
+class BookCommand {}
+
+#[AsController]
+class RegisterBookFeature
+{
+    public function registerBook(): void
+    {
+        $this->handleRegister(new BookCommand());
+    }
+
+    #[AsEventListener]
+    public function handleRegister(BookCommand $command): void
+    {
+        // violation: the Application layer must not depend on Infrastructure
+        $this->registerBook();
+    }
+}

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -1,3 +1,45 @@
+# Method-level layers (new in 4.x)
+
+Deptrac can now assign individual class methods to layers via `scope: method`
+collectors and the opt-in `method` analyser type. See
+[Method-level layers](collectors.md#method-level-layers-collector-scope).
+
+Notes for existing setups:
+
+- Analysis results are unchanged unless you add `method` to `analyser.types`
+  or use `scope: method` collectors.
+- The AST cache format changed; existing caches are invalidated automatically
+  once, so the first run after upgrading does a full re-parse. Method
+  references are only extracted when the config opts into method-level
+  analysis (`method` in `analyser.types`, or any collector with
+  `scope: method`), so projects that don't opt in keep the previous parse
+  cost and cache size. Toggling the opt-in invalidates the cache once in
+  either direction.
+- New enum cases were added: `EmitterType::METHOD_TOKEN`,
+  `DependencyType::METHOD_CALL`, `ClassMethodVisibility`. Exhaustive `match`
+  statements over these enums in custom extensions may need a new arm.
+  `DependencyType::METHOD_CALL` dependencies (whose dependent token is a
+  `ClassMethodToken`) appear in parsed class references only in projects that
+  opted into method-level analysis.
+- `ClassLikeReference` gained an optional `$methods` constructor parameter
+  (appended last) and a `methods` property listing the new
+  `ClassMethodReference` objects. Custom `AstFileReferenceCacheInterface`
+  implementations must account for the new serialized shape: add
+  `ClassMethodReference`, `ClassMethodToken` and `ClassMethodVisibility` to
+  any `allowed_classes` allowlist used when unserializing, and invalidate
+  previously written cache entries themselves — the automatic invalidation
+  only covers the built-in file cache.
+- Violations attributed to a method use the token format `Class::method()`.
+  When you newly assign a method to a layer, baseline entries referring to
+  dependencies inside that method need to be regenerated.
+- Configs using method-level layers require this deptrac version or newer.
+  On older versions, `method` in `analyser.types` fails loudly, but a
+  `scope: method` collector key alone is **silently ignored** — the collector
+  falls back to matching the whole class, producing different results with no
+  warning. When sharing one config across machines with mixed deptrac
+  versions, always pair `scope: method` collectors with the `method` analyser
+  type so outdated versions fail instead of silently diverging.
+
 # Upgrade from 1.0.2 to 2.0.0
 
 ### Dropped functionality

--- a/src/Contract/Ast/AstMap/ClassLikeReference.php
+++ b/src/Contract/Ast/AstMap/ClassLikeReference.php
@@ -15,6 +15,7 @@ final class ClassLikeReference extends TaggedTokenReference
      * @param AstInherit[] $inherits
      * @param DependencyToken[] $dependencies
      * @param array<string,list<string>> $tags
+     * @param ClassMethodReference[] $methods
      */
     public function __construct(
         private readonly ClassLikeToken $classLikeName,
@@ -23,6 +24,7 @@ final class ClassLikeReference extends TaggedTokenReference
         public readonly array $dependencies = [],
         public readonly array $tags = [],
         private readonly ?FileReference $fileReference = null,
+        public readonly array $methods = [],
     ) {
         parent::__construct($tags);
         $this->type = $classLikeType ?? ClassLikeType::TYPE_CLASSLIKE;
@@ -36,7 +38,8 @@ final class ClassLikeReference extends TaggedTokenReference
             $this->inherits,
             $this->dependencies,
             $this->tags,
-            $astFileReference
+            $astFileReference,
+            $this->methods
         );
     }
 

--- a/src/Contract/Ast/AstMap/ClassMethodReference.php
+++ b/src/Contract/Ast/AstMap/ClassMethodReference.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deptrac\Deptrac\Contract\Ast\AstMap;
+
+/**
+ * @psalm-immutable
+ */
+final class ClassMethodReference extends TaggedTokenReference
+{
+    /**
+     * @param FileOccurrence|null $declaration null for methods deptrac has not parsed (e.g. on vendor classes)
+     * @param DependencyToken[] $dependencies dependencies declared inside the method (signature, attributes and body);
+     *                                        they are also part of the owning ClassLikeReference's dependencies
+     * @param array<string,list<string>> $tags
+     */
+    public function __construct(
+        private readonly ClassMethodToken $methodToken,
+        public readonly ClassMethodVisibility $visibility,
+        public readonly bool $isStatic,
+        public readonly ?FileOccurrence $declaration = null,
+        public readonly array $dependencies = [],
+        public readonly array $tags = [],
+    ) {
+        parent::__construct($tags);
+    }
+
+    public function getFilepath(): ?string
+    {
+        return $this->declaration?->filepath;
+    }
+
+    public function getToken(): ClassMethodToken
+    {
+        return $this->methodToken;
+    }
+}

--- a/src/Contract/Ast/AstMap/ClassMethodToken.php
+++ b/src/Contract/Ast/AstMap/ClassMethodToken.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deptrac\Deptrac\Contract\Ast\AstMap;
+
+/**
+ * @psalm-immutable
+ */
+final class ClassMethodToken implements TokenInterface
+{
+    private function __construct(
+        private readonly ClassLikeToken $classLikeToken,
+        private readonly string $methodName,
+    ) {}
+
+    public static function fromFQCNAndMethodName(string $className, string $methodName): self
+    {
+        return new self(ClassLikeToken::fromFQCN($className), $methodName);
+    }
+
+    public static function fromClassTokenAndMethodName(ClassLikeToken $classLikeToken, string $methodName): self
+    {
+        return new self($classLikeToken, $methodName);
+    }
+
+    public function getClassToken(): ClassLikeToken
+    {
+        return $this->classLikeToken;
+    }
+
+    public function getMethodName(): string
+    {
+        return $this->methodName;
+    }
+
+    public function match(string $pattern): bool
+    {
+        return 1 === preg_match($pattern, $this->toString());
+    }
+
+    public function toString(): string
+    {
+        return $this->classLikeToken->toString().'::'.$this->methodName.'()';
+    }
+
+    public function equals(TokenInterface $token): bool
+    {
+        return $token instanceof self && $this->toString() === $token->toString();
+    }
+}

--- a/src/Contract/Ast/AstMap/ClassMethodVisibility.php
+++ b/src/Contract/Ast/AstMap/ClassMethodVisibility.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deptrac\Deptrac\Contract\Ast\AstMap;
+
+enum ClassMethodVisibility: string
+{
+    case TYPE_PUBLIC = 'public';
+    case TYPE_PROTECTED = 'protected';
+    case TYPE_PRIVATE = 'private';
+}

--- a/src/Contract/Ast/AstMap/DependencyType.php
+++ b/src/Contract/Ast/AstMap/DependencyType.php
@@ -33,4 +33,7 @@ enum DependencyType: string
     // Function call that could not be resolved at parse-time and can only be
     // resolved at run-time. Usually means an internal PHP function call.
     case UNRESOLVED_FUNCTION_CALL = 'unresolved_function_call';
+    // Intra-class dispatch ($this->method(), self::method(), static::method());
+    // the dependent token is a ClassMethodToken of the enclosing class.
+    case METHOD_CALL = 'method_call';
 }

--- a/src/Contract/Config/Collector/BoolConfig.php
+++ b/src/Contract/Config/Collector/BoolConfig.php
@@ -60,6 +60,6 @@ final class BoolConfig extends CollectorConfig
             'must' => array_map(static fn (CollectorConfig $v) => $v->toArray(), $this->must),
             'private' => $this->private,
             'type' => $this->collectorType->value,
-        ];
+        ] + $this->scopeToArray();
     }
 }

--- a/src/Contract/Config/Collector/ComposerConfig.php
+++ b/src/Contract/Config/Collector/ComposerConfig.php
@@ -52,6 +52,6 @@ final class ComposerConfig extends CollectorConfig
             'packages' => $this->packages,
             'private' => $this->private,
             'type' => $this->collectorType->value,
-        ];
+        ] + $this->scopeToArray();
     }
 }

--- a/src/Contract/Config/Collector/SuperGlobalConfig.php
+++ b/src/Contract/Config/Collector/SuperGlobalConfig.php
@@ -30,6 +30,6 @@ final class SuperGlobalConfig extends CollectorConfig
             'private' => $this->private,
             'type' => $this->collectorType->value,
             'value' => $this->config,
-        ];
+        ] + $this->scopeToArray();
     }
 }

--- a/src/Contract/Config/CollectorConfig.php
+++ b/src/Contract/Config/CollectorConfig.php
@@ -7,11 +7,23 @@ namespace Deptrac\Deptrac\Contract\Config;
 abstract class CollectorConfig
 {
     protected bool $private = false;
+    protected CollectorScope $scope = CollectorScope::TYPE_CLASS;
     protected CollectorType $collectorType;
 
     public function private(): self
     {
         $this->private = true;
+
+        return $this;
+    }
+
+    /**
+     * Apply this collector to class methods instead of whole tokens, assigning
+     * matching methods to the layer on their own.
+     */
+    public function forMethods(): self
+    {
+        $this->scope = CollectorScope::TYPE_METHOD;
 
         return $this;
     }
@@ -22,6 +34,12 @@ abstract class CollectorConfig
         return [
             'type' => $this->collectorType->value,
             'private' => $this->private,
-        ];
+        ] + $this->scopeToArray();
+    }
+
+    /** @return array{scope?: string} */
+    final protected function scopeToArray(): array
+    {
+        return CollectorScope::TYPE_CLASS === $this->scope ? [] : ['scope' => $this->scope->value];
     }
 }

--- a/src/Contract/Config/CollectorScope.php
+++ b/src/Contract/Config/CollectorScope.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deptrac\Deptrac\Contract\Config;
+
+/**
+ * Restricts which token references a collector is applied to.
+ *
+ * TYPE_CLASS (the default) applies the collector to the references deptrac
+ * assigns by default: class-likes, functions, files and superglobals.
+ * TYPE_METHOD applies the collector to class method references only, assigning
+ * individual methods to a layer of their own.
+ */
+enum CollectorScope: string
+{
+    case TYPE_CLASS = 'class';
+    case TYPE_METHOD = 'method';
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return array_map(
+            static fn (self $scope): string => $scope->value,
+            self::cases()
+        );
+    }
+}

--- a/src/Contract/Config/ConfigurableCollectorConfig.php
+++ b/src/Contract/Config/ConfigurableCollectorConfig.php
@@ -105,7 +105,7 @@ abstract class ConfigurableCollectorConfig extends CollectorConfig
     }
 
     /**
-     * @return array{private: bool, type: string, value: string}
+     * @return array{private: bool, type: string, value: string, scope?: string}
      */
     public function toArray(): array
     {
@@ -113,7 +113,7 @@ abstract class ConfigurableCollectorConfig extends CollectorConfig
             'value' => $this->config,
             'type' => $this->collectorType->value,
             'private' => $this->private,
-        ];
+        ] + $this->scopeToArray();
     }
 
     private static function regex(string $regex): string

--- a/src/Contract/Config/EmitterType.php
+++ b/src/Contract/Config/EmitterType.php
@@ -12,6 +12,7 @@ enum EmitterType: string
     case FUNCTION_TOKEN = 'function';
     case FUNCTION_CALL = 'function_call';
     case FUNCTION_SUPERGLOBAL_TOKEN = 'function_superglobal';
+    case METHOD_TOKEN = 'method';
     case USE_TOKEN = 'use';
 
     /**

--- a/src/Contract/Layer/LayerResolverInterface.php
+++ b/src/Contract/Layer/LayerResolverInterface.php
@@ -27,6 +27,7 @@ interface LayerResolverInterface
 
     /**
      * @throws InvalidLayerDefinitionException
+     * @throws InvalidCollectorDefinitionException
      */
     public function has(string $layer): bool;
 }

--- a/src/Core/Analyser/AnalyserException.php
+++ b/src/Core/Analyser/AnalyserException.php
@@ -50,4 +50,9 @@ final class AnalyserException extends RuntimeException implements ExceptionInter
     {
         return new self('Circular layer dependency.', 0, $e);
     }
+
+    public static function methodGranularityDisabled(): self
+    {
+        return new self("Method-level analysis is not enabled. Add 'method' to analyser.types or declare a collector with 'scope: method'.");
+    }
 }

--- a/src/Core/Analyser/DependencyLayersAnalyser.php
+++ b/src/Core/Analyser/DependencyLayersAnalyser.php
@@ -9,6 +9,7 @@ use Deptrac\Deptrac\Contract\Analyser\AnalysisResult;
 use Deptrac\Deptrac\Contract\Analyser\PostProcessEvent;
 use Deptrac\Deptrac\Contract\Analyser\ProcessEvent;
 use Deptrac\Deptrac\Contract\Ast\AstException;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodToken;
 use Deptrac\Deptrac\Contract\Ast\CouldNotParseFileException;
 use Deptrac\Deptrac\Contract\Layer\InvalidCollectorDefinitionException;
 use Deptrac\Deptrac\Contract\Layer\InvalidLayerDefinitionException;
@@ -59,6 +60,12 @@ class DependencyLayersAnalyser
                 $dependent = $dependency->getDependent();
                 $dependentRef = $this->tokenResolver->resolve($dependent, $astMap);
                 $dependentLayers = $this->layerResolver->getLayersForReference($dependentRef);
+
+                // a method without layers of its own belongs to its class's layers
+                if ([] === $dependentLayers && $dependent instanceof ClassMethodToken) {
+                    $dependentRef = $this->tokenResolver->resolve($dependent->getClassToken(), $astMap);
+                    $dependentLayers = $this->layerResolver->getLayersForReference($dependentRef);
+                }
 
                 foreach ($dependerLayers as $dependerLayer) {
                     $event = new ProcessEvent(

--- a/src/Core/Analyser/LayerForTokenAnalyser.php
+++ b/src/Core/Analyser/LayerForTokenAnalyser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Deptrac\Deptrac\Core\Analyser;
 
 use Deptrac\Deptrac\Contract\Ast\AstException;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodReference;
 use Deptrac\Deptrac\Contract\Ast\AstMap\TokenReferenceInterface;
 use Deptrac\Deptrac\Contract\Ast\CouldNotParseFileException;
 use Deptrac\Deptrac\Contract\Layer\InvalidCollectorDefinitionException;
@@ -26,6 +27,7 @@ class LayerForTokenAnalyser
         private readonly AstMapExtractor $astMapExtractor,
         private readonly TokenResolver $tokenResolver,
         private readonly LayerResolverInterface $layerResolver,
+        private readonly bool $methodGranularity = true,
     ) {}
 
     /**
@@ -50,6 +52,9 @@ class LayerForTokenAnalyser
                     $astMap
                 ),
                 TokenType::FILE => $this->findLayersForReferences($astMap->getFileReferences(), $tokenName, $astMap),
+                TokenType::METHOD => $this->methodGranularity
+                    ? $this->findLayersForReferences($this->methodReferences($astMap), $tokenName, $astMap)
+                    : throw AnalyserException::methodGranularityDisabled(),
             };
         } catch (UnrecognizedTokenException $e) {
             throw AnalyserException::unrecognizedToken($e);
@@ -62,6 +67,21 @@ class LayerForTokenAnalyser
         } catch (CouldNotParseFileException $e) {
             throw AnalyserException::couldNotParseFile($e);
         }
+    }
+
+    /**
+     * @return list<ClassMethodReference>
+     */
+    private function methodReferences(AstMap $astMap): array
+    {
+        $methodReferences = [];
+        foreach ($astMap->getClassLikeReferences() as $classReference) {
+            foreach ($classReference->methods as $methodReference) {
+                $methodReferences[] = $methodReference;
+            }
+        }
+
+        return $methodReferences;
     }
 
     /**

--- a/src/Core/Analyser/TokenInLayerAnalyser.php
+++ b/src/Core/Analyser/TokenInLayerAnalyser.php
@@ -80,6 +80,16 @@ class TokenInLayerAnalyser
                 }
             }
 
+            if (in_array(TokenType::METHOD, $this->tokenTypes, true)) {
+                foreach ($astMap->getClassLikeReferences() as $classReference) {
+                    foreach ($classReference->methods as $methodReference) {
+                        if (array_key_exists($layer, $this->layerResolver->getLayersForReference($methodReference))) {
+                            $matchingTokens[] = [$methodReference->getToken()->toString(), TokenType::METHOD->value];
+                        }
+                    }
+                }
+            }
+
             uasort($matchingTokens, static fn (array $a, array $b): int => $a[0] <=> $b[0]);
 
             return array_values($matchingTokens);

--- a/src/Core/Analyser/TokenType.php
+++ b/src/Core/Analyser/TokenType.php
@@ -11,6 +11,7 @@ enum TokenType: string
     case CLASS_LIKE = 'class-like';
     case FUNCTION = 'function';
     case FILE = 'file';
+    case METHOD = 'method';
 
     public static function tryFromEmitterType(EmitterType $emitterType): ?self
     {

--- a/src/Core/Ast/Parser/Cache/AstFileReferenceFileCache.php
+++ b/src/Core/Ast/Parser/Cache/AstFileReferenceFileCache.php
@@ -8,6 +8,9 @@ use Deptrac\Deptrac\Contract\Ast\AstMap\AstInherit;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeReference;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeToken;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeType;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodReference;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodToken;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodVisibility;
 use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyContext;
 use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyToken;
 use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyType;
@@ -43,7 +46,21 @@ class AstFileReferenceFileCache implements AstFileReferenceDeferredCacheInterfac
     /** @var array<string, bool> */
     private array $parsedFiles = [];
 
-    public function __construct(private readonly string $cacheFile, private readonly string $cacheVersion) {}
+    /**
+     * Bump whenever the serialized structure of FileReference (or anything it
+     * contains) changes, so caches written by the same deptrac version before
+     * the change are discarded.
+     */
+    private const SCHEMA_VERSION = '4';
+
+    private readonly string $cacheVersion;
+
+    public function __construct(private readonly string $cacheFile, string $cacheVersion, bool $methodGranularity = true)
+    {
+        // method granularity changes what is extracted per file, so toggling
+        // it must invalidate entries written with the other setting
+        $this->cacheVersion = $cacheVersion.'/'.self::SCHEMA_VERSION.($methodGranularity ? '/m1' : '/m0');
+    }
 
     public function get(string $filepath): ?FileReference
     {
@@ -111,6 +128,7 @@ class AstFileReferenceFileCache implements AstFileReferenceDeferredCacheInterfac
                         'allowed_classes' => [
                             FileReference::class,
                             ClassLikeReference::class,
+                            ClassMethodReference::class,
                             FunctionReference::class,
                             VariableReference::class,
                             AstInherit::class,
@@ -119,6 +137,8 @@ class AstFileReferenceFileCache implements AstFileReferenceDeferredCacheInterfac
                             FileToken::class,
                             ClassLikeToken::class,
                             ClassLikeType::class,
+                            ClassMethodToken::class,
+                            ClassMethodVisibility::class,
                             FunctionToken::class,
                             SuperGlobalToken::class,
                             FileOccurrence::class,

--- a/src/Core/Dependency/DependencyResolver.php
+++ b/src/Core/Dependency/DependencyResolver.php
@@ -66,6 +66,19 @@ class DependencyResolver
                         )
                     );
                 }
+
+                // dependencies attributed to the inherited class's layered
+                // methods; the inheriting class is accountable for them, too
+                $inheritedClassReference = $astMap->getClassReferenceForToken($inherit->classLikeName);
+                foreach ($inheritedClassReference->methods ?? [] as $methodReference) {
+                    foreach ($dependencyList->getDependenciesByClass($methodReference->getToken()) as $dep) {
+                        $dependencyList->addInheritDependency(
+                            new InheritDependency(
+                                $classLikeName, $dep->getDependent(), $dep, $inherit
+                            )
+                        );
+                    }
+                }
             }
         }
     }

--- a/src/Core/Dependency/TokenResolver.php
+++ b/src/Core/Dependency/TokenResolver.php
@@ -6,6 +6,9 @@ namespace Deptrac\Deptrac\Core\Dependency;
 
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeReference;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeToken;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodReference;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodToken;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodVisibility;
 use Deptrac\Deptrac\Contract\Ast\AstMap\FileReference;
 use Deptrac\Deptrac\Contract\Ast\AstMap\FileToken;
 use Deptrac\Deptrac\Contract\Ast\AstMap\FunctionReference;
@@ -25,10 +28,24 @@ class TokenResolver
     {
         return match (true) {
             $token instanceof ClassLikeToken => $astMap->getClassReferenceForToken($token) ?? new ClassLikeReference($token),
+            $token instanceof ClassMethodToken => $this->resolveClassMethod($token, $astMap),
             $token instanceof FunctionToken => $astMap->getFunctionReferenceForToken($token) ?? new FunctionReference($token),
             $token instanceof SuperGlobalToken => new VariableReference($token),
             $token instanceof FileToken => $astMap->getFileReferenceForToken($token) ?? new FileReference($token->path, [], [], []),
             default => throw UnrecognizedTokenException::cannotCreateReference($token),
         };
+    }
+
+    private function resolveClassMethod(ClassMethodToken $token, AstMap $astMap): ClassMethodReference
+    {
+        $classReference = $astMap->getClassReferenceForToken($token->getClassToken());
+
+        foreach ($classReference->methods ?? [] as $methodReference) {
+            if ($methodReference->getToken()->equals($token)) {
+                return $methodReference;
+            }
+        }
+
+        return new ClassMethodReference($token, ClassMethodVisibility::TYPE_PUBLIC, false);
     }
 }

--- a/src/Core/Layer/LayerResolver.php
+++ b/src/Core/Layer/LayerResolver.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Deptrac\Deptrac\Core\Layer;
 
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodReference;
 use Deptrac\Deptrac\Contract\Ast\AstMap\TokenReferenceInterface;
+use Deptrac\Deptrac\Contract\Config\CollectorScope;
 use Deptrac\Deptrac\Contract\Layer\Collectable;
 use Deptrac\Deptrac\Contract\Layer\CollectorResolverInterface;
+use Deptrac\Deptrac\Contract\Layer\InvalidCollectorDefinitionException;
 use Deptrac\Deptrac\Contract\Layer\InvalidLayerDefinitionException;
 use Deptrac\Deptrac\Contract\Layer\LayerResolverInterface;
 
@@ -49,6 +52,10 @@ class LayerResolver implements LayerResolverInterface
 
         foreach ($this->layers as $layer => $collectables) {
             foreach ($collectables as $collectable) {
+                if (!$this->scopeAccepts($collectable, $reference)) {
+                    continue;
+                }
+
                 $attributes = $collectable->attributes;
 
                 if ($collectable->collector->satisfy($attributes, $reference)) {
@@ -85,12 +92,28 @@ class LayerResolver implements LayerResolverInterface
         $collectables = $this->layers[$layer];
 
         foreach ($collectables as $collectable) {
+            if (!$this->scopeAccepts($collectable, $reference)) {
+                continue;
+            }
+
             if ($collectable->collector->satisfy($collectable->attributes, $reference)) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    /**
+     * Method references are only matched by collectors declared with
+     * "scope: method"; every other reference is only matched by collectors
+     * without it (or with the default "scope: class").
+     */
+    private function scopeAccepts(Collectable $collectable, TokenReferenceInterface $reference): bool
+    {
+        $scope = $collectable->attributes['scope'] ?? CollectorScope::TYPE_CLASS->value;
+
+        return (CollectorScope::TYPE_METHOD->value === $scope) === $reference instanceof ClassMethodReference;
     }
 
     public function has(string $layer): bool
@@ -104,6 +127,7 @@ class LayerResolver implements LayerResolverInterface
 
     /**
      * @throws InvalidLayerDefinitionException
+     * @throws InvalidCollectorDefinitionException
      */
     private function initializeLayers(): void
     {
@@ -121,7 +145,9 @@ class LayerResolver implements LayerResolverInterface
 
             $this->layers[$layerName] = [];
             foreach ($layer['collectors'] ?? [] as $config) {
-                $this->layers[$layerName][] = $this->collectorResolver->resolve($config);
+                $collectable = $this->collectorResolver->resolve($config);
+                $this->assertValidScope($collectable);
+                $this->layers[$layerName][] = $collectable;
             }
             if ([] === $this->layers[$layerName]) {
                 throw InvalidLayerDefinitionException::collectorRequired($layerName);
@@ -133,5 +159,21 @@ class LayerResolver implements LayerResolverInterface
         }
 
         $this->initialized = true;
+    }
+
+    /**
+     * @throws InvalidCollectorDefinitionException
+     */
+    private function assertValidScope(Collectable $collectable): void
+    {
+        if (!array_key_exists('scope', $collectable->attributes)) {
+            return;
+        }
+
+        $scope = $collectable->attributes['scope'];
+
+        if (!is_string($scope) || null === CollectorScope::tryFrom($scope)) {
+            throw InvalidCollectorDefinitionException::invalidCollectorConfiguration(sprintf('Unknown collector scope "%s". Available scopes: %s.', is_string($scope) ? $scope : get_debug_type($scope), implode(', ', CollectorScope::values())));
+        }
     }
 }

--- a/src/DefaultBehavior/Ast/Extractors/MethodCallExtractor.php
+++ b/src/DefaultBehavior/Ast/Extractors/MethodCallExtractor.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deptrac\Deptrac\DefaultBehavior\Ast\Extractors;
+
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodToken;
+use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyType;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ReferenceBuilderInterface;
+use Deptrac\Deptrac\Contract\Ast\NikicReferenceExtractorInterface;
+use Deptrac\Deptrac\Contract\Ast\PHPStanReferenceExtractorInterface;
+use Deptrac\Deptrac\Contract\Ast\TypeScope;
+use Deptrac\Deptrac\DefaultBehavior\Ast\Parser\Helpers\ClassLikeReferenceBuilder;
+use Deptrac\Deptrac\DefaultBehavior\Ast\Parser\Helpers\ClassMethodReferenceBuilder;
+use PhpParser\Node;
+use PhpParser\Node\Expr\CallLike;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\NullsafeMethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\MutatingScope;
+use Throwable;
+
+/**
+ * Emits method-token dependencies for method calls.
+ *
+ * Intra-class dispatch ($this->method(), self::method(), static::method(),
+ * including their first-class callable forms) is tracked with both parsers.
+ * With the PHPStan parser, calls on receivers whose type is statically known
+ * from class context (typed properties, new expressions, return-type chains)
+ * are additionally resolved to the target class's method token.
+ *
+ * Known limitations: dynamic method names are skipped; parent::method() stays
+ * untracked because the parent class is not known at extraction time; calls on
+ * $this inside methods of anonymous classes are attributed to the enclosing
+ * named class; receivers typed only by local variables or parameters are not
+ * resolved (the PHPStan scope is class-level, without flow analysis);
+ * cross-class static calls stay tracked at class level only (they already emit
+ * a static_method dependency).
+ *
+ * @implements NikicReferenceExtractorInterface<CallLike>
+ * @implements PHPStanReferenceExtractorInterface<CallLike>
+ */
+final class MethodCallExtractor implements NikicReferenceExtractorInterface, PHPStanReferenceExtractorInterface
+{
+    public function __construct(private readonly bool $methodGranularity = true) {}
+
+    public function processNode(Node $node, ReferenceBuilderInterface $referenceBuilder, TypeScope $typeScope): void
+    {
+        if (!$this->methodGranularity) {
+            return;
+        }
+
+        $this->resolveSelfDispatch($node, $referenceBuilder);
+    }
+
+    public function processNodeWithPhpStanScope(Node $node, ReferenceBuilderInterface $referenceBuilder, MutatingScope $scope): void
+    {
+        if (!$this->methodGranularity) {
+            return;
+        }
+
+        $this->resolveSelfDispatch($node, $referenceBuilder);
+        $this->resolveCrossClassDispatch($node, $referenceBuilder, $scope);
+    }
+
+    public function getNodeType(): string
+    {
+        return CallLike::class;
+    }
+
+    private function resolveSelfDispatch(CallLike $node, ReferenceBuilderInterface $referenceBuilder): void
+    {
+        $classToken = match (true) {
+            $referenceBuilder instanceof ClassMethodReferenceBuilder => $referenceBuilder->getMethodToken()->getClassToken(),
+            $referenceBuilder instanceof ClassLikeReferenceBuilder => $referenceBuilder->getClassToken(),
+            default => null,
+        };
+
+        if (null === $classToken) {
+            return;
+        }
+
+        $methodName = $this->selfDispatchedMethodName($node);
+
+        if (null === $methodName) {
+            return;
+        }
+
+        $referenceBuilder->dependency(
+            ClassMethodToken::fromClassTokenAndMethodName($classToken, $methodName),
+            $node->getLine(),
+            DependencyType::METHOD_CALL
+        );
+    }
+
+    private function resolveCrossClassDispatch(CallLike $node, ReferenceBuilderInterface $referenceBuilder, MutatingScope $scope): void
+    {
+        // cross-class edges belong to the calling method
+        if (!$referenceBuilder instanceof ClassMethodReferenceBuilder) {
+            return;
+        }
+
+        if (!$node instanceof MethodCall && !$node instanceof NullsafeMethodCall) {
+            return;
+        }
+
+        if (!$node->name instanceof Identifier) {
+            return;
+        }
+
+        // $this receivers are covered by the self-dispatch path
+        if ($node->var instanceof Variable && 'this' === $node->var->name) {
+            return;
+        }
+
+        foreach ($this->resolveReceiverClassNames($node->var, $scope) as $className) {
+            $referenceBuilder->dependency(
+                ClassMethodToken::fromFQCNAndMethodName($className, $node->name->toString()),
+                $node->getLine(),
+                DependencyType::METHOD_CALL
+            );
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function resolveReceiverClassNames(Node\Expr $receiver, MutatingScope $scope): array
+    {
+        try {
+            // the class-level scope has no $this variable, but the type of a
+            // property fetched on $this is known from the class reflection
+            if ($receiver instanceof Node\Expr\PropertyFetch
+                && $receiver->var instanceof Variable
+                && 'this' === $receiver->var->name
+                && $receiver->name instanceof Identifier
+            ) {
+                $classReflection = $scope->getClassReflection();
+                $propertyName = $receiver->name->toString();
+
+                if (null === $classReflection || !$classReflection->hasProperty($propertyName)) {
+                    return [];
+                }
+
+                return $classReflection->getProperty($propertyName, $scope)->getReadableType()->getObjectClassNames();
+            }
+
+            return $scope->getType($receiver)->getObjectClassNames();
+            // @phpstan-ignore catch.neverThrown (getType() throws at runtime for variables unknown to the class-level scope)
+        } catch (Throwable) {
+            return [];
+        }
+    }
+
+    private function selfDispatchedMethodName(CallLike $node): ?string
+    {
+        if ($node instanceof MethodCall
+            && $node->var instanceof Variable
+            && 'this' === $node->var->name
+            && $node->name instanceof Identifier
+        ) {
+            return $node->name->toString();
+        }
+
+        if ($node instanceof StaticCall
+            && $node->class instanceof Name
+            && in_array($node->class->toLowerString(), ['self', 'static'], true)
+            && $node->name instanceof Identifier
+        ) {
+            return $node->name->toString();
+        }
+
+        return null;
+    }
+}

--- a/src/DefaultBehavior/Ast/Parser/Helpers/ClassLikeReferenceBuilder.php
+++ b/src/DefaultBehavior/Ast/Parser/Helpers/ClassLikeReferenceBuilder.php
@@ -7,9 +7,15 @@ namespace Deptrac\Deptrac\DefaultBehavior\Ast\Parser\Helpers;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeReference;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeToken;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeType;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodToken;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodVisibility;
+use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyToken;
 
 final class ClassLikeReferenceBuilder extends ReferenceBuilder
 {
+    /** @var ClassMethodReferenceBuilder[] */
+    private array $methodReferences = [];
+
     /**
      * @param list<string> $tokenTemplates
      * @param array<string,list<string>> $tags
@@ -60,15 +66,53 @@ final class ClassLikeReferenceBuilder extends ReferenceBuilder
         return new self($classTemplates, $filepath, ClassLikeToken::fromFQCN($classLikeName), ClassLikeType::TYPE_INTERFACE, $tags);
     }
 
+    public function getClassToken(): ClassLikeToken
+    {
+        return $this->classLikeToken;
+    }
+
+    /**
+     * @param array<string,list<string>> $tags
+     */
+    public function newMethod(string $methodName, ClassMethodVisibility $visibility, bool $isStatic, int $declaredAtLine, array $tags): ClassMethodReferenceBuilder
+    {
+        $methodReference = ClassMethodReferenceBuilder::create(
+            $this->tokenTemplateLikes,
+            $this->filepath,
+            $this,
+            ClassMethodToken::fromClassTokenAndMethodName($this->classLikeToken, $methodName),
+            $visibility,
+            $isStatic,
+            $declaredAtLine,
+            $tags
+        );
+        $this->methodReferences[] = $methodReference;
+
+        return $methodReference;
+    }
+
+    /** @internal mirrors a method dependency on the owning class-like reference */
+    public function addDependencyToken(DependencyToken $dependency): void
+    {
+        $this->dependencies[] = $dependency;
+    }
+
     /** @internal */
     public function build(): ClassLikeReference
     {
+        $methodReferences = [];
+        foreach ($this->methodReferences as $methodReference) {
+            $methodReferences[] = $methodReference->build();
+        }
+
         return new ClassLikeReference(
             $this->classLikeToken,
             $this->classLikeType,
             $this->inherits,
             $this->dependencies,
-            $this->tags
+            $this->tags,
+            null,
+            $methodReferences
         );
     }
 }

--- a/src/DefaultBehavior/Ast/Parser/Helpers/ClassMethodReferenceBuilder.php
+++ b/src/DefaultBehavior/Ast/Parser/Helpers/ClassMethodReferenceBuilder.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deptrac\Deptrac\DefaultBehavior\Ast\Parser\Helpers;
+
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodReference;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodToken;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodVisibility;
+use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyToken;
+use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyType;
+use Deptrac\Deptrac\Contract\Ast\AstMap\FileOccurrence;
+use Deptrac\Deptrac\Contract\Ast\AstMap\TokenInterface;
+
+final class ClassMethodReferenceBuilder extends ReferenceBuilder
+{
+    /**
+     * @param list<string> $tokenTemplates
+     * @param array<string,list<string>> $tags
+     */
+    private function __construct(
+        array $tokenTemplates,
+        string $filepath,
+        private readonly ClassLikeReferenceBuilder $classReferenceBuilder,
+        private readonly ClassMethodToken $methodToken,
+        private readonly ClassMethodVisibility $visibility,
+        private readonly bool $isStatic,
+        private readonly int $declaredAtLine,
+        private readonly array $tags,
+    ) {
+        parent::__construct($tokenTemplates, $filepath);
+    }
+
+    /**
+     * @param list<string> $tokenTemplates
+     * @param array<string,list<string>> $tags
+     */
+    public static function create(
+        array $tokenTemplates,
+        string $filepath,
+        ClassLikeReferenceBuilder $classReferenceBuilder,
+        ClassMethodToken $methodToken,
+        ClassMethodVisibility $visibility,
+        bool $isStatic,
+        int $declaredAtLine,
+        array $tags,
+    ): self {
+        return new self($tokenTemplates, $filepath, $classReferenceBuilder, $methodToken, $visibility, $isStatic, $declaredAtLine, $tags);
+    }
+
+    public function getMethodToken(): ClassMethodToken
+    {
+        return $this->methodToken;
+    }
+
+    /**
+     * Method dependencies are recorded on the method and mirrored on the owning
+     * class-like reference, so class-level analysis stays complete.
+     */
+    public function dependency(TokenInterface $token, int $occursAtLine, DependencyType $type): static
+    {
+        $dependency = new DependencyToken($token, $this->createContext($occursAtLine, $type));
+        $this->dependencies[] = $dependency;
+        $this->classReferenceBuilder->addDependencyToken($dependency);
+
+        return $this;
+    }
+
+    /** @internal */
+    public function build(): ClassMethodReference
+    {
+        return new ClassMethodReference(
+            $this->methodToken,
+            $this->visibility,
+            $this->isStatic,
+            new FileOccurrence($this->filepath, $this->declaredAtLine),
+            $this->dependencies,
+            $this->tags
+        );
+    }
+}

--- a/src/DefaultBehavior/Ast/Parser/Helpers/NikicFileReferenceVisitor.php
+++ b/src/DefaultBehavior/Ast/Parser/Helpers/NikicFileReferenceVisitor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Deptrac\Deptrac\DefaultBehavior\Ast\Parser\Helpers;
 
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodVisibility;
 use Deptrac\Deptrac\Contract\Ast\NikicReferenceExtractorInterface;
 use Deptrac\Deptrac\Contract\Ast\TypeScope;
 use Deptrac\Deptrac\DefaultBehavior\Ast\DocParsingHelper;
@@ -34,11 +35,15 @@ class NikicFileReferenceVisitor extends NodeVisitorAbstract
 
     private ReferenceBuilder $currentReference;
 
+    /** @var array<int, ReferenceBuilder> reference builders to restore on leave, keyed by spl_object_id of the entered node */
+    private array $savedReferences = [];
+
     /**
      * @param NikicReferenceExtractorInterface<Node> ...$dependencyResolvers
      */
     public function __construct(
         private readonly FileReferenceBuilder $fileReferenceBuilder,
+        private readonly bool $collectMethods,
         NikicReferenceExtractorInterface ...$dependencyResolvers,
     ) {
         $this->currentTypeScope = new TypeScope('');
@@ -82,6 +87,7 @@ class NikicFileReferenceVisitor extends NodeVisitorAbstract
         match (true) {
             $node instanceof Namespace_ => $this->currentTypeScope = new TypeScope($node->name ? $node->name->toCodeString() : ''),
             $node instanceof ClassLike, $node instanceof Node\Stmt\Function_ => $this->enterReferenceChangingNode($node),
+            $node instanceof Node\Stmt\ClassMethod => $this->enterClassMethod($node),
             $node instanceof Node\FunctionLike => $this->enterFunctionLike($node),
             $node instanceof Use_ && Use_::TYPE_NORMAL === $node->type => $this->enterUse($node),
             $node instanceof GroupUse => $this->enterGroupUse($node),
@@ -105,6 +111,11 @@ class NikicFileReferenceVisitor extends NodeVisitorAbstract
             }
         }
 
+        if ($node instanceof Node\Stmt\ClassMethod && isset($this->savedReferences[spl_object_id($node)])) {
+            $this->currentReference = $this->savedReferences[spl_object_id($node)];
+            unset($this->savedReferences[spl_object_id($node)]);
+        }
+
         $this->currentReference = match (true) {
             $node instanceof Node\Stmt\Function_ => $this->fileReferenceBuilder,
             $node instanceof ClassLike && null !== $this->getReferenceName($node) => $this->fileReferenceBuilder,
@@ -112,6 +123,32 @@ class NikicFileReferenceVisitor extends NodeVisitorAbstract
         };
 
         return null;
+    }
+
+    private function enterClassMethod(Node\Stmt\ClassMethod $node): void
+    {
+        // methods of anonymous classes stay attributed to the enclosing reference
+        if ($this->collectMethods && $this->currentReference instanceof ClassLikeReferenceBuilder) {
+            $this->savedReferences[spl_object_id($node)] = $this->currentReference;
+            $this->currentReference = $this->currentReference->newMethod(
+                $node->name->toString(),
+                $this->getVisibility($node),
+                $node->isStatic(),
+                $node->getLine(),
+                $this->getTags($node)
+            );
+        }
+
+        $this->enterFunctionLike($node);
+    }
+
+    private function getVisibility(Node\Stmt\ClassMethod $node): ClassMethodVisibility
+    {
+        return match (true) {
+            $node->isPrivate() => ClassMethodVisibility::TYPE_PRIVATE,
+            $node->isProtected() => ClassMethodVisibility::TYPE_PROTECTED,
+            default => ClassMethodVisibility::TYPE_PUBLIC,
+        };
     }
 
     private function enterReferenceChangingNode(Node\Stmt\Function_|ClassLike $node): void
@@ -171,7 +208,7 @@ class NikicFileReferenceVisitor extends NodeVisitorAbstract
     /**
      * @return array<string,list<string>>
      */
-    private function getTags(ClassLike|Node\Stmt\Function_ $node): array
+    private function getTags(ClassLike|Node\Stmt\Function_|Node\Stmt\ClassMethod $node): array
     {
         $docComment = $node->getDocComment();
         if (null === $docComment) {

--- a/src/DefaultBehavior/Ast/Parser/Helpers/PhpStanFileReferenceVisitor.php
+++ b/src/DefaultBehavior/Ast/Parser/Helpers/PhpStanFileReferenceVisitor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Deptrac\Deptrac\DefaultBehavior\Ast\Parser\Helpers;
 
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodVisibility;
 use Deptrac\Deptrac\Contract\Ast\PHPStanReferenceExtractorInterface;
 use Deptrac\Deptrac\DefaultBehavior\Ast\DocParsingHelper;
 use PhpParser\Node;
@@ -28,6 +29,9 @@ class PhpStanFileReferenceVisitor extends NodeVisitorAbstract
 
     private ReferenceBuilder $currentReference;
 
+    /** @var array<int, ReferenceBuilder> reference builders to restore on leave, keyed by spl_object_id of the entered node */
+    private array $savedReferences = [];
+
     private MutatingScope $scope;
 
     private Lexer $lexer;
@@ -42,6 +46,7 @@ class PhpStanFileReferenceVisitor extends NodeVisitorAbstract
         private readonly ScopeFactory $scopeFactory,
         private readonly ReflectionProvider $reflectionProvider,
         private readonly string $file,
+        private readonly bool $collectMethods,
         PHPStanReferenceExtractorInterface ...$dependencyResolvers,
     ) {
         $this->dependencyResolvers = $dependencyResolvers;
@@ -55,6 +60,7 @@ class PhpStanFileReferenceVisitor extends NodeVisitorAbstract
         match (true) {
             $node instanceof Node\Stmt\Function_ => $this->enterFunction($node),
             $node instanceof ClassLike => $this->enterClassLike($node),
+            $node instanceof Node\Stmt\ClassMethod => $this->enterClassMethod($node),
             default => null,
         };
 
@@ -69,6 +75,11 @@ class PhpStanFileReferenceVisitor extends NodeVisitorAbstract
             }
         }
 
+        if ($node instanceof Node\Stmt\ClassMethod && isset($this->savedReferences[spl_object_id($node)])) {
+            $this->currentReference = $this->savedReferences[spl_object_id($node)];
+            unset($this->savedReferences[spl_object_id($node)]);
+        }
+
         $this->currentReference = match (true) {
             $node instanceof Node\Stmt\Function_ => $this->fileReferenceBuilder,
             $node instanceof ClassLike && null !== $this->getReferenceName($node) => $this->fileReferenceBuilder,
@@ -76,6 +87,30 @@ class PhpStanFileReferenceVisitor extends NodeVisitorAbstract
         };
 
         return null;
+    }
+
+    private function enterClassMethod(Node\Stmt\ClassMethod $node): void
+    {
+        // methods of anonymous classes stay attributed to the enclosing reference
+        if ($this->collectMethods && $this->currentReference instanceof ClassLikeReferenceBuilder) {
+            $this->savedReferences[spl_object_id($node)] = $this->currentReference;
+            $this->currentReference = $this->currentReference->newMethod(
+                $node->name->toString(),
+                $this->getVisibility($node),
+                $node->isStatic(),
+                $node->getLine(),
+                $this->getTags($node)
+            );
+        }
+    }
+
+    private function getVisibility(Node\Stmt\ClassMethod $node): ClassMethodVisibility
+    {
+        return match (true) {
+            $node->isPrivate() => ClassMethodVisibility::TYPE_PRIVATE,
+            $node->isProtected() => ClassMethodVisibility::TYPE_PROTECTED,
+            default => ClassMethodVisibility::TYPE_PUBLIC,
+        };
     }
 
     private function enterClassLike(ClassLike $node): void
@@ -123,7 +158,7 @@ class PhpStanFileReferenceVisitor extends NodeVisitorAbstract
     /**
      * @return array<string,list<string>>
      */
-    private function getTags(ClassLike|Node\Stmt\Function_ $node): array
+    private function getTags(ClassLike|Node\Stmt\Function_|Node\Stmt\ClassMethod $node): array
     {
         $docComment = $node->getDocComment();
         if (null === $docComment) {

--- a/src/DefaultBehavior/Ast/Parser/NikicPhpParser.php
+++ b/src/DefaultBehavior/Ast/Parser/NikicPhpParser.php
@@ -27,6 +27,7 @@ class NikicPhpParser extends AbstractParser
         private readonly Parser $parser,
         private readonly AstFileReferenceCacheInterface $cache,
         private readonly iterable $extractors,
+        private readonly bool $methodGranularity = true,
     ) {
         $this->traverser = new NodeTraverser();
         $this->traverser->addVisitor(new NameResolver());
@@ -39,7 +40,7 @@ class NikicPhpParser extends AbstractParser
         }
 
         $fileReferenceBuilder = FileReferenceBuilder::create($file);
-        $visitor = new NikicFileReferenceVisitor($fileReferenceBuilder, ...$this->extractors);
+        $visitor = new NikicFileReferenceVisitor($fileReferenceBuilder, $this->methodGranularity, ...$this->extractors);
         $nodes = $this->loadNodesFromFile($file);
         $this->traverser->addVisitor($visitor);
         $this->traverser->traverse($nodes);

--- a/src/DefaultBehavior/Ast/Parser/PhpStanParser.php
+++ b/src/DefaultBehavior/Ast/Parser/PhpStanParser.php
@@ -25,6 +25,7 @@ class PhpStanParser extends AbstractParser
         private readonly PhpStanContainerDecorator $phpStanContainer,
         private readonly AstFileReferenceCacheInterface $cache,
         private readonly iterable $extractors,
+        private readonly bool $methodGranularity = true,
     ) {
         $this->traverser = new NodeTraverser();
     }
@@ -43,7 +44,7 @@ class PhpStanParser extends AbstractParser
         }
 
         $fileReferenceBuilder = FileReferenceBuilder::create($file);
-        $visitor = new PhpStanFileReferenceVisitor($fileReferenceBuilder, $scopeFactory, $reflectionProvider, $file, ...$this->extractors);
+        $visitor = new PhpStanFileReferenceVisitor($fileReferenceBuilder, $scopeFactory, $reflectionProvider, $file, $this->methodGranularity, ...$this->extractors);
         $nodes = $this->loadNodesFromFile($file);
         $this->traverser->addVisitor($visitor);
         $this->traverser->traverse($nodes);

--- a/src/DefaultBehavior/Dependency/ClassDependencyEmitter.php
+++ b/src/DefaultBehavior/Dependency/ClassDependencyEmitter.php
@@ -7,12 +7,24 @@ namespace Deptrac\Deptrac\DefaultBehavior\Dependency;
 use Deptrac\Deptrac\Contract\Ast\AstMap\AstMapInterface;
 use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyContext;
 use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyType;
+use Deptrac\Deptrac\Contract\Config\EmitterType;
 use Deptrac\Deptrac\Contract\Dependency\DependencyEmitterInterface;
 use Deptrac\Deptrac\Contract\Dependency\DependencyListInterface;
 use Deptrac\Deptrac\DefaultBehavior\Dependency\Helpers\Dependency;
+use SplObjectStorage;
 
 final class ClassDependencyEmitter implements DependencyEmitterInterface
 {
+    private readonly bool $atMethodGranularity;
+
+    /**
+     * @param array{types?: array<string>} $config
+     */
+    public function __construct(array $config = [])
+    {
+        $this->atMethodGranularity = in_array(EmitterType::METHOD_TOKEN->value, $config['types'] ?? [], true);
+    }
+
     public function getName(): string
     {
         return 'ClassDependencyEmitter';
@@ -23,11 +35,28 @@ final class ClassDependencyEmitter implements DependencyEmitterInterface
         foreach ($astMap->getClassLikeReferences() as $classReference) {
             $classLikeName = $classReference->getToken();
 
+            // when the method emitter is active it owns the method-declared dependencies
+            $methodDependencies = new SplObjectStorage();
+            if ($this->atMethodGranularity) {
+                foreach ($classReference->methods as $methodReference) {
+                    foreach ($methodReference->dependencies as $methodDependency) {
+                        $methodDependencies->attach($methodDependency);
+                    }
+                }
+            }
+
             foreach ($classReference->dependencies as $dependency) {
+                if ($methodDependencies->contains($dependency)) {
+                    continue;
+                }
                 if (DependencyType::SUPERGLOBAL_VARIABLE === $dependency->context->dependencyType) {
                     continue;
                 }
                 if (DependencyType::UNRESOLVED_FUNCTION_CALL === $dependency->context->dependencyType) {
+                    continue;
+                }
+                // intra-class dispatch is emitted at method granularity only
+                if (DependencyType::METHOD_CALL === $dependency->context->dependencyType) {
                     continue;
                 }
 

--- a/src/DefaultBehavior/Dependency/MethodDependencyEmitter.php
+++ b/src/DefaultBehavior/Dependency/MethodDependencyEmitter.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deptrac\Deptrac\DefaultBehavior\Dependency;
+
+use Deptrac\Deptrac\Contract\Ast\AstMap\AstMapInterface;
+use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyType;
+use Deptrac\Deptrac\Contract\Dependency\DependencyEmitterInterface;
+use Deptrac\Deptrac\Contract\Dependency\DependencyListInterface;
+use Deptrac\Deptrac\Contract\Layer\LayerResolverInterface;
+use Deptrac\Deptrac\DefaultBehavior\Dependency\Helpers\Dependency;
+
+/**
+ * Emits the dependencies declared inside class methods.
+ *
+ * A method assigned to at least one layer of its own (via a "scope: method"
+ * collector) becomes the depender for its dependencies, overriding its class's
+ * layers. Dependencies of all other methods stay attributed to the class token,
+ * matching the class-level emitter's behavior.
+ */
+final class MethodDependencyEmitter implements DependencyEmitterInterface
+{
+    public function __construct(private readonly LayerResolverInterface $layerResolver) {}
+
+    public function getName(): string
+    {
+        return 'MethodDependencyEmitter';
+    }
+
+    /**
+     * @throws \Deptrac\Deptrac\Contract\Layer\InvalidLayerDefinitionException
+     * @throws \Deptrac\Deptrac\Contract\Layer\InvalidCollectorDefinitionException
+     * @throws \Deptrac\Deptrac\Contract\Ast\CouldNotParseFileException
+     */
+    public function applyDependencies(AstMapInterface $astMap, DependencyListInterface $dependencyList): void
+    {
+        foreach ($astMap->getClassLikeReferences() as $classReference) {
+            foreach ($classReference->methods as $methodReference) {
+                $isLayered = [] !== $this->layerResolver->getLayersForReference($methodReference);
+                $depender = $isLayered ? $methodReference->getToken() : $classReference->getToken();
+
+                foreach ($methodReference->dependencies as $dependency) {
+                    if (DependencyType::SUPERGLOBAL_VARIABLE === $dependency->context->dependencyType) {
+                        continue;
+                    }
+                    if (DependencyType::UNRESOLVED_FUNCTION_CALL === $dependency->context->dependencyType) {
+                        continue;
+                    }
+
+                    $dependencyList->addDependency(
+                        new Dependency(
+                            $depender,
+                            $dependency->token,
+                            $dependency->context,
+                        )
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/DefaultBehavior/Layer/AttributeCollector.php
+++ b/src/DefaultBehavior/Layer/AttributeCollector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Deptrac\Deptrac\DefaultBehavior\Layer;
 
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeReference;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodReference;
 use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyType;
 use Deptrac\Deptrac\Contract\Ast\AstMap\FileReference;
 use Deptrac\Deptrac\Contract\Ast\AstMap\FunctionReference;
@@ -21,6 +22,7 @@ final class AttributeCollector implements CollectorInterface
         if (!$reference instanceof FileReference
             && !$reference instanceof ClassLikeReference
             && !$reference instanceof FunctionReference
+            && !$reference instanceof ClassMethodReference
         ) {
             return false;
         }

--- a/src/DefaultBehavior/Layer/MethodCollector.php
+++ b/src/DefaultBehavior/Layer/MethodCollector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Deptrac\Deptrac\DefaultBehavior\Layer;
 
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeReference;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodReference;
 use Deptrac\Deptrac\Contract\Ast\AstMap\TokenReferenceInterface;
 use Deptrac\Deptrac\Contract\Ast\ParserInterface;
 use Deptrac\Deptrac\DefaultBehavior\Layer\Helpers\RegexCollector;
@@ -15,6 +16,11 @@ final class MethodCollector extends RegexCollector
 
     public function satisfy(array $config, TokenReferenceInterface $reference): bool
     {
+        // with "scope: method" a single method is matched by its own name
+        if ($reference instanceof ClassMethodReference) {
+            return 1 === preg_match($this->getValidatedPattern($config), $reference->getToken()->getMethodName());
+        }
+
         if (!$reference instanceof ClassLikeReference) {
             return false;
         }

--- a/src/Supportive/Console/Command/CommandRunException.php
+++ b/src/Supportive/Console/Command/CommandRunException.php
@@ -32,6 +32,6 @@ final class CommandRunException extends RuntimeException implements ExceptionInt
 
     public static function analyserException(AnalyserException $e): self
     {
-        return new self('Analysis failed.', 0, $e);
+        return new self('Analysis failed: '.$e->getMessage(), 0, $e);
     }
 }

--- a/src/Supportive/Console/Command/DebugTokenCommand.php
+++ b/src/Supportive/Console/Command/DebugTokenCommand.php
@@ -30,7 +30,7 @@ class DebugTokenCommand extends Command
         parent::configure();
 
         $this->addArgument('token', InputArgument::REQUIRED, 'Full qualified token name to debug');
-        $this->addArgument('type', InputArgument::OPTIONAL, 'Token type (class-like, function, file)', 'class-like');
+        $this->addArgument('type', InputArgument::OPTIONAL, 'Token type (class-like, function, file, method)', 'class-like');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Supportive/DependencyInjection/DeptracExtension.php
+++ b/src/Supportive/DependencyInjection/DeptracExtension.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Deptrac\Deptrac\Supportive\DependencyInjection;
 
+use Deptrac\Deptrac\Contract\Config\CollectorScope;
 use Deptrac\Deptrac\Contract\Config\EmitterType;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 
 use function getcwd;
+use function in_array;
+use function is_array;
 
 /**
  * @psalm-suppress UndefinedDocblockClass
@@ -32,6 +35,56 @@ class DeptracExtension extends Extension implements PrependExtensionInterface
         $container->setParameter('ignore_uncovered_internal_classes', $configs['ignore_uncovered_internal_classes']);
         $container->setParameter('cache_file', $configs['cache_file']);
         $container->setParameter('feature_flags', $configs['feature_flags']);
+        $container->setParameter('method_granularity', self::methodGranularityEnabled($configs));
+    }
+
+    /**
+     * Method references are only extracted (and cached) when the config opts
+     * into method-level analysis, so non-opted projects keep the smaller AST
+     * and cache.
+     *
+     * @param array<mixed> $configs
+     */
+    private static function methodGranularityEnabled(array $configs): bool
+    {
+        $analyser = $configs['analyser'] ?? [];
+        $types = is_array($analyser) ? ($analyser['types'] ?? []) : [];
+        if (is_array($types) && in_array(EmitterType::METHOD_TOKEN->value, $types, true)) {
+            return true;
+        }
+
+        $layers = $configs['layers'] ?? [];
+        foreach (is_array($layers) ? $layers : [] as $layer) {
+            $collectors = is_array($layer) ? ($layer['collectors'] ?? []) : [];
+            foreach (is_array($collectors) ? $collectors : [] as $collectorConfig) {
+                if (is_array($collectorConfig) && self::usesMethodScope($collectorConfig)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<mixed> $collectorConfig
+     */
+    private static function usesMethodScope(array $collectorConfig): bool
+    {
+        if (CollectorScope::TYPE_METHOD->value === ($collectorConfig['scope'] ?? null)) {
+            return true;
+        }
+
+        foreach (['must', 'must_not'] as $key) {
+            $childConfigs = $collectorConfig[$key] ?? [];
+            foreach (is_array($childConfigs) ? $childConfigs : [] as $childConfig) {
+                if (is_array($childConfig) && self::usesMethodScope($childConfig)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     public function prepend(ContainerBuilder $container): void
@@ -71,6 +124,9 @@ class DeptracExtension extends Extension implements PrependExtensionInterface
         }
         if (!$container->hasParameter('feature_flags')) {
             $container->setParameter('feature_flags', ['phpstan_parser' => false]);
+        }
+        if (!$container->hasParameter('method_granularity')) {
+            $container->setParameter('method_granularity', false);
         }
     }
 }

--- a/tests/Contract/Config/CollectorConfigTest.php
+++ b/tests/Contract/Config/CollectorConfigTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Deptrac\Deptrac\Contract\Config;
+
+use Deptrac\Deptrac\Contract\Config\Collector\AttributeConfig;
+use Deptrac\Deptrac\Contract\Config\Collector\BoolConfig;
+use Deptrac\Deptrac\Contract\Config\Collector\MethodConfig;
+use PHPUnit\Framework\TestCase;
+
+final class CollectorConfigTest extends TestCase
+{
+    public function testScopeIsOmittedByDefault(): void
+    {
+        self::assertSame(
+            [
+                'value' => 'SomeAttribute',
+                'type' => 'attribute',
+                'private' => false,
+            ],
+            AttributeConfig::create('SomeAttribute')->toArray(),
+        );
+    }
+
+    public function testForMethodsAddsMethodScope(): void
+    {
+        self::assertSame(
+            [
+                'value' => 'SomeAttribute',
+                'type' => 'attribute',
+                'private' => false,
+                'scope' => 'method',
+            ],
+            AttributeConfig::create('SomeAttribute')->forMethods()->toArray(),
+        );
+    }
+
+    public function testForMethodsOnBoolConfig(): void
+    {
+        $config = BoolConfig::create()
+            ->must(MethodConfig::create('handle'))
+            ->forMethods()
+            ->toArray()
+        ;
+
+        self::assertSame('method', $config['scope']);
+    }
+}

--- a/tests/Core/Analyser/DependencyLayersAnalyserTest.php
+++ b/tests/Core/Analyser/DependencyLayersAnalyserTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Deptrac\Deptrac\Core\Analyser;
+
+use Deptrac\Deptrac\Contract\Analyser\EventHelper;
+use Deptrac\Deptrac\Contract\Layer\Collectable;
+use Deptrac\Deptrac\Contract\Layer\CollectorResolverInterface;
+use Deptrac\Deptrac\Contract\OutputFormatter\BaselineMapperInterface;
+use Deptrac\Deptrac\Contract\Result\OutputResult;
+use Deptrac\Deptrac\Contract\Result\Violation;
+use Deptrac\Deptrac\Core\Analyser\DependencyLayersAnalyser;
+use Deptrac\Deptrac\Core\Ast\AstLoader;
+use Deptrac\Deptrac\Core\Ast\AstMapExtractor;
+use Deptrac\Deptrac\Core\Ast\Parser\Cache\AstFileReferenceInMemoryCache;
+use Deptrac\Deptrac\Core\Ast\Parser\TypeResolver;
+use Deptrac\Deptrac\Core\Dependency\DependencyResolver;
+use Deptrac\Deptrac\Core\Dependency\TokenResolver;
+use Deptrac\Deptrac\Core\InputCollector\InputCollectorInterface;
+use Deptrac\Deptrac\Core\Layer\LayerProvider;
+use Deptrac\Deptrac\Core\Layer\LayerResolver;
+use Deptrac\Deptrac\DefaultBehavior\Analyser\AllowDependencyHandler;
+use Deptrac\Deptrac\DefaultBehavior\Analyser\DependsOnDisallowedLayer;
+use Deptrac\Deptrac\DefaultBehavior\Analyser\MatchingLayersHandler;
+use Deptrac\Deptrac\DefaultBehavior\Analyser\UncoveredDependentHandler;
+use Deptrac\Deptrac\DefaultBehavior\Ast\Extractors\ClassLikeExtractor;
+use Deptrac\Deptrac\DefaultBehavior\Ast\Extractors\FunctionLikeExtractor;
+use Deptrac\Deptrac\DefaultBehavior\Ast\Extractors\MethodCallExtractor;
+use Deptrac\Deptrac\DefaultBehavior\Ast\Extractors\NewExtractor;
+use Deptrac\Deptrac\DefaultBehavior\Ast\Parser\Helpers\PhpStanContainerDecorator;
+use Deptrac\Deptrac\DefaultBehavior\Ast\Parser\NikicPhpParser;
+use Deptrac\Deptrac\DefaultBehavior\Dependency\ClassDependencyEmitter;
+use Deptrac\Deptrac\DefaultBehavior\Dependency\MethodDependencyEmitter;
+use Deptrac\Deptrac\DefaultBehavior\Layer\AttributeCollector;
+use Deptrac\Deptrac\DefaultBehavior\Layer\ClassNameRegexCollector;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+/**
+ * End-to-end test for method-level layer granularity: methods collected into a
+ * layer of their own ("scope: method") are checked against the ruleset
+ * independently of their class.
+ */
+final class DependencyLayersAnalyserTest extends TestCase
+{
+    private const FIXTURE_NAMESPACE = 'Tests\Deptrac\Deptrac\Core\Analyser\Fixtures';
+
+    public function testMethodGranularityDetectsInwardDependencyViolation(): void
+    {
+        $result = OutputResult::fromAnalysisResult($this->analyseFixture());
+
+        $violations = $result->violations();
+        self::assertCount(1, $violations);
+
+        $violation = $violations[0];
+        self::assertInstanceOf(Violation::class, $violation);
+        self::assertSame('Application', $violation->getDependerLayer());
+        self::assertSame('Infrastructure', $violation->getDependentLayer());
+        self::assertSame(
+            self::FIXTURE_NAMESPACE.'\RegisterBookFeature::handleRegister()',
+            $violation->getDependency()->getDepender()->toString()
+        );
+        self::assertSame(
+            self::FIXTURE_NAMESPACE.'\RegisterBookFeature::registerBook()',
+            $violation->getDependency()->getDependent()->toString()
+        );
+        self::assertSame(24, $violation->getDependency()->getContext()->fileOccurrence->line);
+    }
+
+    public function testMethodGranularityAllowsOutwardDependencies(): void
+    {
+        $result = OutputResult::fromAnalysisResult($this->analyseFixture());
+
+        // Infrastructure (the class, including the unlayered registerBook method)
+        // may depend on Application (the handleRegister method and BookCommand)
+        $allowedDescriptions = array_map(
+            static fn ($allowed): string => sprintf(
+                '%s -> %s (%s -> %s)',
+                $allowed->getDependency()->getDepender()->toString(),
+                $allowed->getDependency()->getDependent()->toString(),
+                $allowed->getDependerLayer(),
+                $allowed->getDependentLayer()
+            ),
+            $result->allowed()
+        );
+
+        self::assertEqualsCanonicalizing(
+            [
+                self::FIXTURE_NAMESPACE.'\RegisterBookFeature -> '.self::FIXTURE_NAMESPACE.'\RegisterBookFeature::handleRegister() (Infrastructure -> Application)',
+                self::FIXTURE_NAMESPACE.'\RegisterBookFeature -> '.self::FIXTURE_NAMESPACE.'\BookCommand (Infrastructure -> Application)',
+            ],
+            $allowedDescriptions
+        );
+
+        self::assertSame([], $result->warnings);
+        self::assertSame([], $result->errors);
+    }
+
+    private function analyseFixture(): \Deptrac\Deptrac\Contract\Analyser\AnalysisResult
+    {
+        $fixtureFile = __DIR__.'/Fixtures/RegisterBookFeature.php';
+
+        $typeResolver = new TypeResolver();
+        $phpStanContainer = new PhpStanContainerDecorator(__DIR__, __DIR__, [$fixtureFile]);
+        $parser = new NikicPhpParser(
+            (new ParserFactory())->createForNewestSupportedVersion(),
+            new AstFileReferenceInMemoryCache(),
+            [
+                new ClassLikeExtractor($phpStanContainer, $typeResolver),
+                new FunctionLikeExtractor($typeResolver),
+                new NewExtractor($typeResolver),
+                new MethodCallExtractor(),
+            ]
+        );
+
+        $inputCollector = new class($fixtureFile) implements InputCollectorInterface {
+            public function __construct(private readonly string $file) {}
+
+            public function collect(): array
+            {
+                return [$this->file];
+            }
+        };
+
+        $eventDispatcher = new EventDispatcher();
+        $astMapExtractor = new AstMapExtractor($inputCollector, new AstLoader($parser, $eventDispatcher));
+
+        $collectorResolver = new class implements CollectorResolverInterface {
+            public function resolve(array $config): Collectable
+            {
+                $collector = match ($config['type']) {
+                    'attribute' => new AttributeCollector(),
+                    'classNameRegex' => new ClassNameRegexCollector(),
+                };
+
+                return new Collectable($collector, $config);
+            }
+        };
+
+        $layerResolver = new LayerResolver($collectorResolver, [
+            [
+                'name' => 'Infrastructure',
+                'collectors' => [
+                    ['type' => 'attribute', 'value' => 'AsController'],
+                ],
+            ],
+            [
+                'name' => 'Application',
+                'collectors' => [
+                    ['type' => 'attribute', 'value' => 'AsEventListener', 'scope' => 'method'],
+                    ['type' => 'classNameRegex', 'value' => '/BookCommand$/'],
+                ],
+            ],
+        ]);
+
+        $analyserConfig = ['types' => ['class', 'method']];
+        $emitters = [
+            'class' => new ClassDependencyEmitter($analyserConfig),
+            'method' => new MethodDependencyEmitter($layerResolver),
+        ];
+        $emitterLocator = new class($emitters) implements ContainerInterface {
+            public function __construct(private readonly array $emitters) {}
+
+            public function get(string $id): mixed
+            {
+                return $this->emitters[$id];
+            }
+
+            public function has(string $id): bool
+            {
+                return isset($this->emitters[$id]);
+            }
+        };
+
+        $baselineMapper = new class implements BaselineMapperInterface {
+            public function fromPHPListToString(array $groupedViolations): string
+            {
+                return '';
+            }
+
+            public function loadViolations(): array
+            {
+                return [];
+            }
+        };
+        $eventHelper = new EventHelper(new LayerProvider(['Infrastructure' => ['Application']]), $baselineMapper);
+
+        $eventDispatcher->addSubscriber(new UncoveredDependentHandler(true));
+        $eventDispatcher->addSubscriber(new MatchingLayersHandler());
+        $eventDispatcher->addSubscriber(new DependsOnDisallowedLayer($eventHelper));
+        $eventDispatcher->addSubscriber(new AllowDependencyHandler());
+
+        $analyser = new DependencyLayersAnalyser(
+            $astMapExtractor,
+            new DependencyResolver($analyserConfig, $emitterLocator, $eventDispatcher),
+            new TokenResolver(),
+            $layerResolver,
+            $eventDispatcher
+        );
+
+        return $analyser->analyse();
+    }
+}

--- a/tests/Core/Analyser/Fixtures/RegisterBookFeature.php
+++ b/tests/Core/Analyser/Fixtures/RegisterBookFeature.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Deptrac\Deptrac\Core\Analyser\Fixtures;
+
+#[\Attribute]
+class AsController {}
+
+#[\Attribute]
+class AsEventListener {}
+
+class BookCommand {}
+
+#[AsController]
+class RegisterBookFeature
+{
+    public function registerBook(): void
+    {
+        $this->handleRegister(new BookCommand());
+    }
+
+    #[AsEventListener]
+    public function handleRegister(BookCommand $command): void
+    {
+        $this->registerBook();
+    }
+}

--- a/tests/Core/Ast/Parser/ClassMethodExtractionTest.php
+++ b/tests/Core/Ast/Parser/ClassMethodExtractionTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Deptrac\Deptrac\Core\Ast\Parser;
+
+use Closure;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodReference;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodVisibility;
+use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyToken;
+use Deptrac\Deptrac\Contract\Ast\ParserInterface;
+use Deptrac\Deptrac\Core\Ast\Parser\Cache\AstFileReferenceInMemoryCache;
+use Deptrac\Deptrac\Core\Ast\Parser\TypeResolver;
+use Deptrac\Deptrac\DefaultBehavior\Ast\Extractors\ClassLikeExtractor;
+use Deptrac\Deptrac\DefaultBehavior\Ast\Extractors\ExpressionExtractor;
+use Deptrac\Deptrac\DefaultBehavior\Ast\Extractors\FunctionLikeExtractor;
+use Deptrac\Deptrac\DefaultBehavior\Ast\Extractors\NewExtractor;
+use Deptrac\Deptrac\DefaultBehavior\Ast\Parser\Helpers\PhpStanContainerDecorator;
+use Deptrac\Deptrac\DefaultBehavior\Ast\Parser\NikicPhpParser;
+use Deptrac\Deptrac\DefaultBehavior\Ast\Parser\PhpStanParser;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ClassMethodExtractionTest extends TestCase
+{
+    private const FIXTURE_NAMESPACE = 'Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures';
+
+    #[DataProvider('createParser')]
+    public function testMethodReferencesAreExtracted(Closure $parserBuilder): void
+    {
+        $filePath = __DIR__.'/Fixtures/MethodGranularity.php';
+        $parser = $parserBuilder($filePath);
+        $astFileReference = $parser->parseFile($filePath);
+
+        $classReferences = $astFileReference->classLikeReferences;
+        self::assertCount(5, $classReferences);
+
+        $featureClass = $classReferences[4];
+        self::assertSame(self::FIXTURE_NAMESPACE.'\GranularFeature', $featureClass->getToken()->toString());
+        self::assertCount(3, $featureClass->methods);
+
+        [$handle, $build, $audit] = $featureClass->methods;
+
+        self::assertSame(self::FIXTURE_NAMESPACE.'\GranularFeature::handle()', $handle->getToken()->toString());
+        self::assertSame(self::FIXTURE_NAMESPACE.'\GranularFeature', $handle->getToken()->getClassToken()->toString());
+        self::assertSame('handle', $handle->getToken()->getMethodName());
+        self::assertSame(ClassMethodVisibility::TYPE_PUBLIC, $handle->visibility);
+        self::assertFalse($handle->isStatic);
+        self::assertSame($filePath, $handle->getFilepath());
+        // the declaration starts at the method's first attribute
+        self::assertSame(21, $handle->declaration->line);
+        self::assertTrue($handle->hasTag('@granular-tag'));
+        self::assertSame(['handles registration'], $handle->getTagLines('@granular-tag'));
+        self::assertEqualsCanonicalizing(
+            [
+                self::FIXTURE_NAMESPACE.'\GranularMethodAttribute::21 (attribute)',
+                self::FIXTURE_NAMESPACE.'\GranularDependencyA::22 (parameter)',
+                self::FIXTURE_NAMESPACE.'\GranularDependencyB::25 (new)',
+            ],
+            self::getDependenciesAsString($handle)
+        );
+
+        self::assertSame(self::FIXTURE_NAMESPACE.'\GranularFeature::build()', $build->getToken()->toString());
+        self::assertSame(ClassMethodVisibility::TYPE_PROTECTED, $build->visibility);
+        self::assertTrue($build->isStatic);
+
+        self::assertSame(self::FIXTURE_NAMESPACE.'\GranularFeature::audit()', $audit->getToken()->toString());
+        self::assertSame(ClassMethodVisibility::TYPE_PRIVATE, $audit->visibility);
+        self::assertFalse($audit->isStatic);
+        self::assertEqualsCanonicalizing(
+            [
+                self::FIXTURE_NAMESPACE.'\GranularDependencyA::29 (returntype)',
+                // methods of anonymous classes belong to the enclosing method
+                self::FIXTURE_NAMESPACE.'\GranularDependencyB::34 (new)',
+            ],
+            self::getDependenciesAsString($build)
+        );
+    }
+
+    #[DataProvider('createParser')]
+    public function testMethodDependenciesAreMirroredOnClassReference(Closure $parserBuilder): void
+    {
+        $filePath = __DIR__.'/Fixtures/MethodGranularity.php';
+        $parser = $parserBuilder($filePath);
+        $astFileReference = $parser->parseFile($filePath);
+
+        $featureClass = $astFileReference->classLikeReferences[4];
+
+        // the class keeps the complete dependency list, including method-owned dependencies
+        self::assertCount(6, $featureClass->dependencies);
+        self::assertContains(
+            self::FIXTURE_NAMESPACE.'\GranularClassAttribute::15 (attribute)',
+            array_map(
+                static fn (DependencyToken $dependency): string => "{$dependency->token->toString()}::{$dependency->context->fileOccurrence->line} ({$dependency->context->dependencyType->value})",
+                $featureClass->dependencies
+            )
+        );
+
+        foreach ($featureClass->methods as $method) {
+            foreach ($method->dependencies as $dependency) {
+                self::assertContains($dependency, $featureClass->dependencies);
+            }
+        }
+    }
+
+    public function testMethodTemplatesAreNotReportedAsDependencies(): void
+    {
+        $filePath = __DIR__.'/Fixtures/MethodTemplates.php';
+        $typeResolver = new TypeResolver();
+        $phpStanContainer = new PhpStanContainerDecorator(__DIR__, __DIR__, [$filePath]);
+        $parser = new NikicPhpParser(
+            (new ParserFactory())->createForNewestSupportedVersion(),
+            new AstFileReferenceInMemoryCache(),
+            [new ExpressionExtractor($phpStanContainer, $typeResolver)]
+        );
+
+        $astFileReference = $parser->parseFile($filePath);
+        [$method] = $astFileReference->classLikeReferences[0]->methods;
+
+        // the method's @template name must not resolve to a class dependency
+        self::assertSame([], $method->dependencies);
+    }
+
+    #[DataProvider('createParserWithoutMethodGranularity')]
+    public function testMethodReferencesAreNotExtractedWhenMethodGranularityIsDisabled(Closure $parserBuilder): void
+    {
+        $filePath = __DIR__.'/Fixtures/MethodGranularity.php';
+        $parser = $parserBuilder($filePath);
+        $astFileReference = $parser->parseFile($filePath);
+
+        $featureClass = $astFileReference->classLikeReferences[4];
+        self::assertSame(self::FIXTURE_NAMESPACE.'\GranularFeature', $featureClass->getToken()->toString());
+        self::assertSame([], $featureClass->methods);
+
+        // the class still records the complete dependency list
+        self::assertCount(6, $featureClass->dependencies);
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function getDependenciesAsString(ClassMethodReference $methodReference): array
+    {
+        return array_map(
+            static fn (DependencyToken $dependency): string => "{$dependency->token->toString()}::{$dependency->context->fileOccurrence->line} ({$dependency->context->dependencyType->value})",
+            $methodReference->dependencies
+        );
+    }
+
+    /**
+     * @return list<array{ParserInterface}>
+     */
+    public static function createParser(): array
+    {
+        return [
+            'Nikic Parser' => [self::createNikicParser(...)],
+            'PHPStan Parser' => [self::createPhpStanParser(...)],
+        ];
+    }
+
+    /**
+     * @return list<array{ParserInterface}>
+     */
+    public static function createParserWithoutMethodGranularity(): array
+    {
+        return [
+            'Nikic Parser' => [static fn (string $filePath): NikicPhpParser => self::createNikicParser($filePath, false)],
+            'PHPStan Parser' => [static fn (string $filePath): PhpStanParser => self::createPhpStanParser($filePath, false)],
+        ];
+    }
+
+    public static function createNikicParser(string $filePath, bool $methodGranularity = true): NikicPhpParser
+    {
+        $typeResolver = new TypeResolver();
+        $phpStanContainer = new PhpStanContainerDecorator(__DIR__, __DIR__, [$filePath]);
+
+        $cache = new AstFileReferenceInMemoryCache();
+        $extractors = [
+            new ClassLikeExtractor($phpStanContainer, $typeResolver),
+            new FunctionLikeExtractor($typeResolver),
+            new NewExtractor($typeResolver),
+        ];
+
+        return new NikicPhpParser(
+            (new ParserFactory())->createForNewestSupportedVersion(), $cache, $extractors, $methodGranularity
+        );
+    }
+
+    public static function createPhpStanParser(string $filePath, bool $methodGranularity = true): PhpStanParser
+    {
+        $typeResolver = new TypeResolver();
+        $phpStanContainer = new PhpStanContainerDecorator(__DIR__, __DIR__, [$filePath]);
+
+        $cache = new AstFileReferenceInMemoryCache();
+        $extractors = [
+            new ClassLikeExtractor($phpStanContainer, $typeResolver),
+            new FunctionLikeExtractor($typeResolver),
+            new NewExtractor($typeResolver),
+        ];
+
+        return new PhpStanParser($phpStanContainer, $cache, $extractors, $methodGranularity);
+    }
+}

--- a/tests/Core/Ast/Parser/Fixtures/MethodCalls.php
+++ b/tests/Core/Ast/Parser/Fixtures/MethodCalls.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures;
+
+class MethodCallsBase
+{
+    protected function inherited(): void {}
+}
+
+class MethodCallsFixture extends MethodCallsBase
+{
+    public function caller(): void
+    {
+        $this->target();
+        self::staticTarget();
+        static::staticTarget();
+        parent::inherited();
+        $callable = $this->target(...);
+        $name = 'target';
+        $this->$name();
+        $closure = function (): void {
+            $this->target();
+        };
+    }
+
+    private function target(): void {}
+
+    public static function staticTarget(): void {}
+}
+
+function methodCallsHelper(MethodCallsFixture $fixture): void
+{
+    $fixture->target();
+}

--- a/tests/Core/Ast/Parser/Fixtures/MethodCallsCrossClass.php
+++ b/tests/Core/Ast/Parser/Fixtures/MethodCallsCrossClass.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures;
+
+class CrossClassTarget
+{
+    public function targetMethod(): void {}
+
+    public static function create(): CrossClassTarget
+    {
+        return new CrossClassTarget();
+    }
+}
+
+class CrossClassCaller
+{
+    private CrossClassTarget $target;
+
+    public function callViaProperty(): void
+    {
+        $this->target->targetMethod();
+    }
+
+    public function callViaNew(): void
+    {
+        (new CrossClassTarget())->targetMethod();
+    }
+
+    public function callViaStaticFactory(): void
+    {
+        CrossClassTarget::create()->targetMethod();
+    }
+
+    public function callViaParameter(CrossClassTarget $param): void
+    {
+        $param->targetMethod();
+    }
+}

--- a/tests/Core/Ast/Parser/Fixtures/MethodGranularity.php
+++ b/tests/Core/Ast/Parser/Fixtures/MethodGranularity.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures;
+
+#[\Attribute]
+class GranularMethodAttribute {}
+
+#[\Attribute]
+class GranularClassAttribute {}
+
+class GranularDependencyA {}
+
+class GranularDependencyB {}
+
+#[GranularClassAttribute]
+class GranularFeature
+{
+    /**
+     * @granular-tag handles registration
+     */
+    #[GranularMethodAttribute]
+    public function handle(GranularDependencyA $a): void
+    {
+        $callback = function (): void {
+            new GranularDependencyB();
+        };
+    }
+
+    protected static function build(): ?GranularDependencyA
+    {
+        $anon = new class {
+            public function anonMethod(): void
+            {
+                new GranularDependencyB();
+            }
+        };
+    }
+
+    private function audit(): void {}
+}

--- a/tests/Core/Ast/Parser/Fixtures/MethodTemplates.php
+++ b/tests/Core/Ast/Parser/Fixtures/MethodTemplates.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures;
+
+class MethodTemplatesFixture
+{
+    /**
+     * @template T of object
+     *
+     * @param T $value
+     */
+    public function withTemplate($value): void
+    {
+        /** @var T $copy */
+        $copy = $value;
+    }
+}

--- a/tests/Core/Ast/Parser/MethodCallExtractorTest.php
+++ b/tests/Core/Ast/Parser/MethodCallExtractorTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Deptrac\Deptrac\Core\Ast\Parser;
+
+use Closure;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodReference;
+use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyToken;
+use Deptrac\Deptrac\Contract\Ast\ParserInterface;
+use Deptrac\Deptrac\Core\Ast\Parser\Cache\AstFileReferenceInMemoryCache;
+use Deptrac\Deptrac\DefaultBehavior\Ast\Extractors\MethodCallExtractor;
+use Deptrac\Deptrac\DefaultBehavior\Ast\Parser\Helpers\PhpStanContainerDecorator;
+use Deptrac\Deptrac\DefaultBehavior\Ast\Parser\NikicPhpParser;
+use Deptrac\Deptrac\DefaultBehavior\Ast\Parser\PhpStanParser;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class MethodCallExtractorTest extends TestCase
+{
+    private const FIXTURE_NAMESPACE = 'Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures';
+
+    #[DataProvider('createParser')]
+    public function testSelfDispatchIsRecordedOnTheCallingMethod(Closure $parserBuilder): void
+    {
+        $filePath = __DIR__.'/Fixtures/MethodCalls.php';
+        $parser = $parserBuilder($filePath);
+        $astFileReference = $parser->parseFile($filePath);
+
+        [$baseClass, $fixtureClass] = $astFileReference->classLikeReferences;
+
+        [$caller, $target, $staticTarget] = $fixtureClass->methods;
+        self::assertSame(self::FIXTURE_NAMESPACE.'\MethodCallsFixture::caller()', $caller->getToken()->toString());
+
+        self::assertEqualsCanonicalizing(
+            [
+                self::FIXTURE_NAMESPACE.'\MethodCallsFixture::target()::14 (method_call)',
+                self::FIXTURE_NAMESPACE.'\MethodCallsFixture::staticTarget()::15 (method_call)',
+                self::FIXTURE_NAMESPACE.'\MethodCallsFixture::staticTarget()::16 (method_call)',
+                // parent::inherited() (17) and the dynamic $this->$name() (20) stay untracked
+                self::FIXTURE_NAMESPACE.'\MethodCallsFixture::target()::18 (method_call)',
+                // calls inside closures belong to the enclosing method
+                self::FIXTURE_NAMESPACE.'\MethodCallsFixture::target()::22 (method_call)',
+            ],
+            self::getDependenciesAsString($caller)
+        );
+
+        self::assertSame([], self::getDependenciesAsString($target));
+        self::assertSame([], self::getDependenciesAsString($staticTarget));
+        self::assertSame([], $baseClass->methods[0]->dependencies);
+
+        // receiver is a plain variable, not $this
+        self::assertSame([], $astFileReference->functionReferences[0]->dependencies);
+    }
+
+    public function testCrossClassDispatchIsResolvedWithThePhpStanParser(): void
+    {
+        $filePath = __DIR__.'/Fixtures/MethodCallsCrossClass.php';
+        $parser = self::createPhpStanParser($filePath);
+        $astFileReference = $parser->parseFile($filePath);
+
+        [$targetClass, $callerClass] = $astFileReference->classLikeReferences;
+        [$viaProperty, $viaNew, $viaStaticFactory, $viaParameter] = $callerClass->methods;
+
+        $target = self::FIXTURE_NAMESPACE.'\CrossClassTarget';
+
+        self::assertSame(
+            ["{$target}::targetMethod()::21 (method_call)"],
+            self::getDependenciesAsString($viaProperty)
+        );
+        self::assertSame(
+            ["{$target}::targetMethod()::26 (method_call)"],
+            self::getDependenciesAsString($viaNew)
+        );
+        self::assertSame(
+            // the static create() call itself stays tracked at class level only
+            ["{$target}::targetMethod()::31 (method_call)"],
+            self::getDependenciesAsString($viaStaticFactory)
+        );
+        // limitation: parameters are unknown to the class-level scope
+        self::assertSame([], self::getDependenciesAsString($viaParameter));
+    }
+
+    public function testCrossClassDispatchIsNotResolvedWithTheNikicParser(): void
+    {
+        $filePath = __DIR__.'/Fixtures/MethodCallsCrossClass.php';
+        $parser = self::createNikicParser($filePath);
+        $astFileReference = $parser->parseFile($filePath);
+
+        foreach ($astFileReference->classLikeReferences[1]->methods as $methodReference) {
+            self::assertSame([], self::getDependenciesAsString($methodReference));
+        }
+    }
+
+    #[DataProvider('createParserWithoutMethodGranularity')]
+    public function testNoMethodCallsAreRecordedWhenMethodGranularityIsDisabled(Closure $parserBuilder): void
+    {
+        $filePath = __DIR__.'/Fixtures/MethodCalls.php';
+        $astFileReference = $parserBuilder($filePath)->parseFile($filePath);
+
+        foreach ($astFileReference->classLikeReferences as $classReference) {
+            self::assertSame([], $classReference->methods);
+            self::assertSame([], $classReference->dependencies);
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function getDependenciesAsString(ClassMethodReference $methodReference): array
+    {
+        return array_map(
+            static fn (DependencyToken $dependency): string => "{$dependency->token->toString()}::{$dependency->context->fileOccurrence->line} ({$dependency->context->dependencyType->value})",
+            $methodReference->dependencies
+        );
+    }
+
+    /**
+     * @return list<array{ParserInterface}>
+     */
+    public static function createParser(): array
+    {
+        return [
+            'Nikic Parser' => [self::createNikicParser(...)],
+            'PHPStan Parser' => [self::createPhpStanParser(...)],
+        ];
+    }
+
+    /**
+     * @return list<array{ParserInterface}>
+     */
+    public static function createParserWithoutMethodGranularity(): array
+    {
+        return [
+            'Nikic Parser' => [static fn (string $filePath): NikicPhpParser => self::createNikicParser($filePath, false)],
+            'PHPStan Parser' => [static fn (string $filePath): PhpStanParser => self::createPhpStanParser($filePath, false)],
+        ];
+    }
+
+    public static function createNikicParser(string $filePath, bool $methodGranularity = true): NikicPhpParser
+    {
+        return new NikicPhpParser(
+            (new ParserFactory())->createForNewestSupportedVersion(),
+            new AstFileReferenceInMemoryCache(),
+            [new MethodCallExtractor($methodGranularity)],
+            $methodGranularity
+        );
+    }
+
+    public static function createPhpStanParser(string $filePath, bool $methodGranularity = true): PhpStanParser
+    {
+        $phpStanContainer = new PhpStanContainerDecorator(__DIR__, __DIR__, [$filePath]);
+
+        return new PhpStanParser($phpStanContainer, new AstFileReferenceInMemoryCache(), [new MethodCallExtractor($methodGranularity)], $methodGranularity);
+    }
+}

--- a/tests/Core/Dependency/DependencyResolverTest.php
+++ b/tests/Core/Dependency/DependencyResolverTest.php
@@ -8,7 +8,13 @@ use Deptrac\Deptrac\Contract\Ast\AstMap\AstInherit;
 use Deptrac\Deptrac\Contract\Ast\AstMap\AstInheritType;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeReference;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeToken;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodReference;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodToken;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodVisibility;
+use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyContext;
+use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyType;
 use Deptrac\Deptrac\Contract\Ast\AstMap\FileOccurrence;
+use Deptrac\Deptrac\Contract\Ast\AstMap\FileReference;
 use Deptrac\Deptrac\Contract\Config\EmitterType;
 use Deptrac\Deptrac\Contract\Dependency\DependencyInterface;
 use Deptrac\Deptrac\Contract\Dependency\PostEmitEvent;
@@ -25,6 +31,7 @@ use Deptrac\Deptrac\DefaultBehavior\Dependency\ClassSuperglobalDependencyEmitter
 use Deptrac\Deptrac\DefaultBehavior\Dependency\FileDependencyEmitter;
 use Deptrac\Deptrac\DefaultBehavior\Dependency\FunctionDependencyEmitter;
 use Deptrac\Deptrac\DefaultBehavior\Dependency\FunctionSuperglobalDependencyEmitter;
+use Deptrac\Deptrac\DefaultBehavior\Dependency\Helpers\Dependency;
 use Deptrac\Deptrac\DefaultBehavior\Dependency\UsesDependencyEmitter;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -189,5 +196,48 @@ final class DependencyResolverTest extends TestCase
         $dep->method('getDependent')->willReturn(ClassLikeToken::fromFQCN($className.'_b'));
 
         return $dep;
+    }
+
+    public function testFlattensMethodAttributedDependenciesOfInheritedClasses(): void
+    {
+        $parentToken = ClassLikeToken::fromFQCN('App\ParentFeature');
+        $methodToken = ClassMethodToken::fromFQCNAndMethodName('App\ParentFeature', 'handle');
+
+        $parentMethod = new ClassMethodReference(
+            $methodToken,
+            ClassMethodVisibility::TYPE_PUBLIC,
+            false,
+            new FileOccurrence('parent.php', 5)
+        );
+        $parentReference = new ClassLikeReference($parentToken, null, [], [], [], null, [$parentMethod]);
+
+        $childToken = ClassLikeToken::fromFQCN('App\ChildFeature');
+        $inherit = new AstInherit($parentToken, new FileOccurrence('child.php', 3), AstInheritType::EXTENDS);
+        $childReference = new ClassLikeReference($childToken, null, [$inherit]);
+
+        $astMap = new AstMap([
+            new FileReference('parent.php', [$parentReference], [], []),
+            new FileReference('child.php', [$childReference], [], []),
+        ]);
+
+        $dependencyList = new DependencyList();
+        $methodDependency = new Dependency(
+            $methodToken,
+            ClassLikeToken::fromFQCN('App\SomeService'),
+            new DependencyContext(new FileOccurrence('parent.php', 7), DependencyType::NEW)
+        );
+        $dependencyList->addDependency($methodDependency);
+
+        DependencyResolver::flattenDependencies($astMap, $dependencyList);
+
+        $inheritDependencies = array_values(array_filter(
+            $dependencyList->getDependenciesAndInheritDependencies(),
+            static fn (DependencyInterface $dependency): bool => $dependency instanceof InheritDependency
+        ));
+
+        self::assertCount(1, $inheritDependencies);
+        self::assertSame('App\ChildFeature', $inheritDependencies[0]->getDepender()->toString());
+        self::assertSame('App\SomeService', $inheritDependencies[0]->getDependent()->toString());
+        self::assertSame($methodDependency, $inheritDependencies[0]->originalDependency);
     }
 }

--- a/tests/Core/Dependency/Emitter/ClassDependencyEmitterTest.php
+++ b/tests/Core/Dependency/Emitter/ClassDependencyEmitterTest.php
@@ -42,4 +42,42 @@ final class ClassDependencyEmitterTest extends TestCase
         self::assertContains('Foo\Bar:36 on Foo\string2', $deps);
         self::assertContains('Foo\Bar:42 on Foo\SomeClass', $deps);
     }
+
+    public function testDoesNotEmitIntraClassMethodCalls(): void
+    {
+        $deps = $this->getEmittedDependencies(
+            new ClassDependencyEmitter(),
+            __DIR__.'/Fixtures/MethodCalls.php'
+        );
+
+        self::assertSame(['Foo\MethodCallClass:11 on Foo\SomeClass'], $deps);
+    }
+
+    public function testSkipsMethodDependenciesAtMethodGranularity(): void
+    {
+        $deps = $this->getEmittedDependencies(
+            new ClassDependencyEmitter(['types' => ['class', 'method']]),
+            __DIR__.'/Fixtures/MethodGranularity.php'
+        );
+
+        // every dependency of the fixture lives inside a method, so the method emitter owns them all
+        self::assertSame([], $deps);
+    }
+
+    public function testEmitsMethodDependenciesAtClassGranularity(): void
+    {
+        $deps = $this->getEmittedDependencies(
+            new ClassDependencyEmitter(['types' => ['class']]),
+            __DIR__.'/Fixtures/MethodGranularity.php'
+        );
+
+        self::assertEqualsCanonicalizing(
+            [
+                'Foo\MethodEmitterClass:7 on Foo\SomeParam',
+                'Foo\MethodEmitterClass:10 on Foo\SomeClass',
+                'Foo\MethodEmitterClass:15 on Foo\OtherClass',
+            ],
+            $deps
+        );
+    }
 }

--- a/tests/Core/Dependency/Emitter/EmitterTrait.php
+++ b/tests/Core/Dependency/Emitter/EmitterTrait.php
@@ -15,6 +15,7 @@ use Deptrac\Deptrac\DefaultBehavior\Ast\Extractors\ClassExtractor;
 use Deptrac\Deptrac\DefaultBehavior\Ast\Extractors\FunctionCallExtractor;
 use Deptrac\Deptrac\DefaultBehavior\Ast\Extractors\FunctionLikeExtractor;
 use Deptrac\Deptrac\DefaultBehavior\Ast\Extractors\InstanceofExtractor;
+use Deptrac\Deptrac\DefaultBehavior\Ast\Extractors\MethodCallExtractor;
 use Deptrac\Deptrac\DefaultBehavior\Ast\Extractors\NewExtractor;
 use Deptrac\Deptrac\DefaultBehavior\Ast\Extractors\PropertyExtractor;
 use Deptrac\Deptrac\DefaultBehavior\Ast\Extractors\StaticCallExtractor;
@@ -50,6 +51,7 @@ trait EmitterTrait
                 new ClassExtractor(),
                 new UseExtractor(),
                 new InstanceofExtractor($typeResolver),
+                new MethodCallExtractor(),
                 new StaticCallExtractor($typeResolver),
                 new StaticPropertyFetchExtractor($typeResolver),
                 new NewExtractor($typeResolver),

--- a/tests/Core/Dependency/Emitter/Fixtures/MethodCalls.php
+++ b/tests/Core/Dependency/Emitter/Fixtures/MethodCalls.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Foo;
+
+class MethodCallClass
+{
+    public function a(): void
+    {
+        $this->b();
+        self::c();
+        new SomeClass();
+    }
+
+    private function b(): void {}
+
+    public static function c(): void {}
+}

--- a/tests/Core/Dependency/Emitter/Fixtures/MethodGranularity.php
+++ b/tests/Core/Dependency/Emitter/Fixtures/MethodGranularity.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Foo;
+
+class MethodEmitterClass
+{
+    public function layered(SomeParam $p): void
+    {
+        $this->plain();
+        new SomeClass();
+    }
+
+    public function plain(): void
+    {
+        new OtherClass();
+    }
+}

--- a/tests/Core/Dependency/Emitter/MethodDependencyEmitterTest.php
+++ b/tests/Core/Dependency/Emitter/MethodDependencyEmitterTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Deptrac\Deptrac\Core\Dependency\Emitter;
+
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodReference;
+use Deptrac\Deptrac\Contract\Ast\AstMap\TokenReferenceInterface;
+use Deptrac\Deptrac\Contract\Layer\LayerResolverInterface;
+use Deptrac\Deptrac\DefaultBehavior\Dependency\MethodDependencyEmitter;
+use PHPUnit\Framework\TestCase;
+
+final class MethodDependencyEmitterTest extends TestCase
+{
+    use EmitterTrait;
+
+    public function testGetName(): void
+    {
+        $emitter = new MethodDependencyEmitter($this->buildLayerResolverForMethods([]));
+
+        self::assertSame('MethodDependencyEmitter', $emitter->getName());
+    }
+
+    public function testLayeredMethodBecomesDepender(): void
+    {
+        $deps = $this->getEmittedDependencies(
+            new MethodDependencyEmitter($this->buildLayerResolverForMethods(['layered'])),
+            __DIR__.'/Fixtures/MethodGranularity.php'
+        );
+
+        self::assertEqualsCanonicalizing(
+            [
+                'Foo\MethodEmitterClass::layered():7 on Foo\SomeParam',
+                'Foo\MethodEmitterClass::layered():9 on Foo\MethodEmitterClass::plain()',
+                'Foo\MethodEmitterClass::layered():10 on Foo\SomeClass',
+                // methods without a layer of their own keep the class as depender
+                'Foo\MethodEmitterClass:15 on Foo\OtherClass',
+            ],
+            $deps
+        );
+    }
+
+    public function testUnlayeredMethodsKeepClassDepender(): void
+    {
+        $deps = $this->getEmittedDependencies(
+            new MethodDependencyEmitter($this->buildLayerResolverForMethods([])),
+            __DIR__.'/Fixtures/MethodGranularity.php'
+        );
+
+        self::assertEqualsCanonicalizing(
+            [
+                'Foo\MethodEmitterClass:7 on Foo\SomeParam',
+                'Foo\MethodEmitterClass:9 on Foo\MethodEmitterClass::plain()',
+                'Foo\MethodEmitterClass:10 on Foo\SomeClass',
+                'Foo\MethodEmitterClass:15 on Foo\OtherClass',
+            ],
+            $deps
+        );
+    }
+
+    /**
+     * @param list<string> $layeredMethodNames
+     */
+    private function buildLayerResolverForMethods(array $layeredMethodNames): LayerResolverInterface
+    {
+        return new class($layeredMethodNames) implements LayerResolverInterface {
+            public function __construct(private readonly array $layeredMethodNames) {}
+
+            public function getLayersForReference(TokenReferenceInterface $reference): array
+            {
+                if ($reference instanceof ClassMethodReference
+                    && in_array($reference->getToken()->getMethodName(), $this->layeredMethodNames, true)
+                ) {
+                    return ['App' => true];
+                }
+
+                return [];
+            }
+
+            public function isReferenceInLayer(string $layer, TokenReferenceInterface $reference): bool
+            {
+                return [] !== $this->getLayersForReference($reference);
+            }
+
+            public function has(string $layer): bool
+            {
+                return false;
+            }
+        };
+    }
+}

--- a/tests/Core/Dependency/TokenResolverTest.php
+++ b/tests/Core/Dependency/TokenResolverTest.php
@@ -6,14 +6,20 @@ namespace Tests\Deptrac\Deptrac\Core\Dependency;
 
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeReference;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeToken;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodReference;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodToken;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodVisibility;
+use Deptrac\Deptrac\Contract\Ast\AstMap\FileOccurrence;
 use Deptrac\Deptrac\Contract\Ast\AstMap\FileReference;
 use Deptrac\Deptrac\Contract\Ast\AstMap\FileToken;
 use Deptrac\Deptrac\Contract\Ast\AstMap\FunctionReference;
 use Deptrac\Deptrac\Contract\Ast\AstMap\FunctionToken;
 use Deptrac\Deptrac\Contract\Ast\AstMap\SuperGlobalToken;
+use Deptrac\Deptrac\Contract\Ast\AstMap\TokenInterface;
 use Deptrac\Deptrac\Contract\Ast\AstMap\VariableReference;
 use Deptrac\Deptrac\Core\Ast\AstMap;
 use Deptrac\Deptrac\Core\Dependency\TokenResolver;
+use Deptrac\Deptrac\Core\Dependency\UnrecognizedTokenException;
 use PHPUnit\Framework\TestCase;
 
 final class TokenResolverTest extends TestCase
@@ -124,5 +130,66 @@ final class TokenResolverTest extends TestCase
 
         self::assertInstanceOf(FileReference::class, $resolved);
         self::assertSame($token->toString(), $resolved->getToken()->toString());
+    }
+
+    public function testResolvesClassMethodFromAstMap(): void
+    {
+        $methodToken = ClassMethodToken::fromFQCNAndMethodName('App\Foo', 'bar');
+        $methodReference = new ClassMethodReference(
+            $methodToken,
+            ClassMethodVisibility::TYPE_PUBLIC,
+            false,
+            new FileOccurrence('path/to/file.php', 3)
+        );
+        $classReference = new ClassLikeReference(
+            ClassLikeToken::fromFQCN('App\Foo'),
+            null,
+            [],
+            [],
+            [],
+            null,
+            [$methodReference]
+        );
+        $fileReference = new FileReference('path/to/file.php', [$classReference], [], []);
+        $astMap = new AstMap([$fileReference]);
+
+        $resolved = $this->resolver->resolve($methodToken, $astMap);
+
+        self::assertSame('path/to/file.php', $resolved->getFilepath());
+        self::assertSame($methodToken->toString(), $resolved->getToken()->toString());
+    }
+
+    public function testResolvesClassMethodNotInAstMap(): void
+    {
+        $astMap = new AstMap([]);
+        $token = ClassMethodToken::fromFQCNAndMethodName('App\Foo', 'unknownMethod');
+
+        $resolved = $this->resolver->resolve($token, $astMap);
+
+        self::assertInstanceOf(ClassMethodReference::class, $resolved);
+        self::assertNull($resolved->getFilepath());
+        self::assertSame($token->toString(), $resolved->getToken()->toString());
+        self::assertSame(ClassMethodVisibility::TYPE_PUBLIC, $resolved->visibility);
+        self::assertFalse($resolved->isStatic);
+    }
+
+    public function testThrowsOnUnrecognizedToken(): void
+    {
+        $astMap = new AstMap([]);
+        $token = new class implements TokenInterface {
+            public function toString(): string
+            {
+                return 'custom-token';
+            }
+
+            public function equals(TokenInterface $token): bool
+            {
+                return false;
+            }
+        };
+
+        $this->expectException(UnrecognizedTokenException::class);
+
+        $this->resolver->resolve($token, $astMap);
     }
 }

--- a/tests/Core/Layer/Collector/AttributeCollectorTest.php
+++ b/tests/Core/Layer/Collector/AttributeCollectorTest.php
@@ -7,6 +7,7 @@ namespace Tests\Deptrac\Deptrac\Core\Layer\Collector;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeReference;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeToken;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeType;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodVisibility;
 use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyType;
 use Deptrac\Deptrac\Contract\Ast\AstMap\SuperGlobalToken;
 use Deptrac\Deptrac\Contract\Ast\AstMap\VariableReference;
@@ -74,5 +75,32 @@ final class AttributeCollectorTest extends TestCase
         );
 
         self::assertFalse($actual);
+    }
+
+    #[DataProvider('dataProviderSatisfy')]
+    public function testSatisfyMethodReference(array $config, bool $expected): void
+    {
+        $classReferenceBuilder = FileReferenceBuilder::create('Foo.php')->newClass('App\Foo', [], []);
+        $classReferenceBuilder
+            ->newMethod('bar', ClassMethodVisibility::TYPE_PUBLIC, false, 2, [])
+            ->dependency(ClassLikeToken::fromFQCN('App\MyException'), 3, DependencyType::THROW)
+            ->dependency(ClassLikeToken::fromFQCN('App\MyAttribute'), 2, DependencyType::ATTRIBUTE)
+            ->dependency(ClassLikeToken::fromFQCN('MyAttribute'), 2, DependencyType::ATTRIBUTE)
+        ;
+        $methodReference = $classReferenceBuilder->build()->methods[0];
+
+        $actual = $this->collector->satisfy($config, $methodReference);
+
+        self::assertSame($expected, $actual);
+    }
+
+    public function testMethodReferenceDoesNotSatisfyOnClassLevelAttribute(): void
+    {
+        $classReferenceBuilder = FileReferenceBuilder::create('Foo.php')->newClass('App\Foo', [], []);
+        $classReferenceBuilder->dependency(ClassLikeToken::fromFQCN('App\MyAttribute'), 1, DependencyType::ATTRIBUTE);
+        $classReferenceBuilder->newMethod('bar', ClassMethodVisibility::TYPE_PUBLIC, false, 3, []);
+        $methodReference = $classReferenceBuilder->build()->methods[0];
+
+        self::assertFalse($this->collector->satisfy(['value' => 'MyAttribute'], $methodReference));
     }
 }

--- a/tests/Core/Layer/Collector/MethodCollectorTest.php
+++ b/tests/Core/Layer/Collector/MethodCollectorTest.php
@@ -6,6 +6,10 @@ namespace Tests\Deptrac\Deptrac\Core\Layer\Collector;
 
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeReference;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeToken;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodReference;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodToken;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodVisibility;
+use Deptrac\Deptrac\Contract\Ast\AstMap\FileOccurrence;
 use Deptrac\Deptrac\Contract\Ast\AstMap\FunctionReference;
 use Deptrac\Deptrac\Contract\Ast\AstMap\FunctionToken;
 use Deptrac\Deptrac\Contract\Layer\InvalidCollectorDefinitionException;
@@ -127,5 +131,30 @@ final class MethodCollectorTest extends TestCase
             ['value' => '/'],
             $astClassReference,
         );
+    }
+
+    public static function provideSatisfyMethodReference(): iterable
+    {
+        yield 'matches own method name' => [['value' => 'handle'], 'handleRegister', true];
+        yield 'does not match other method name' => [['value' => 'build'], 'handleRegister', false];
+    }
+
+    #[DataProvider('provideSatisfyMethodReference')]
+    public function testSatisfyMethodReference(array $configuration, string $methodName, bool $expected): void
+    {
+        $methodReference = new ClassMethodReference(
+            ClassMethodToken::fromFQCNAndMethodName('foo', $methodName),
+            ClassMethodVisibility::TYPE_PUBLIC,
+            false,
+            new FileOccurrence('foo.php', 1)
+        );
+
+        // the parser must not be consulted for method references
+        $this->astParser
+            ->expects(self::never())
+            ->method('getMethodNamesForClassLikeReference')
+        ;
+
+        self::assertSame($expected, $this->collector->satisfy($configuration, $methodReference));
     }
 }

--- a/tests/Core/Layer/LayerResolverTest.php
+++ b/tests/Core/Layer/LayerResolverTest.php
@@ -6,9 +6,14 @@ namespace Tests\Deptrac\Deptrac\Core\Layer;
 
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeReference;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeToken;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodReference;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodToken;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodVisibility;
+use Deptrac\Deptrac\Contract\Ast\AstMap\FileOccurrence;
 use Deptrac\Deptrac\Contract\Layer\Collectable;
 use Deptrac\Deptrac\Contract\Layer\CollectorInterface;
 use Deptrac\Deptrac\Contract\Layer\CollectorResolverInterface;
+use Deptrac\Deptrac\Contract\Layer\InvalidCollectorDefinitionException;
 use Deptrac\Deptrac\Contract\Layer\InvalidLayerDefinitionException;
 use Deptrac\Deptrac\Core\Layer\LayerResolver;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -180,6 +185,74 @@ final class LayerResolverTest extends TestCase
             [],
             $resolver->getLayersForReference($reference)
         );
+    }
+
+    public function testCollectorScopeSeparatesMethodAndClassReferences(): void
+    {
+        $resolver = new LayerResolver(
+            $this->buildCollectorResolverWithFakeCollector(),
+            [
+                [
+                    'name' => 'classes',
+                    'collectors' => [
+                        [
+                            'type' => 'custom',
+                            'satisfy' => true,
+                        ],
+                    ],
+                ],
+                [
+                    'name' => 'methods',
+                    'collectors' => [
+                        [
+                            'type' => 'custom',
+                            'satisfy' => true,
+                            'scope' => 'method',
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $classReference = new ClassLikeReference(ClassLikeToken::fromFQCN('foo'));
+        $methodReference = new ClassMethodReference(
+            ClassMethodToken::fromFQCNAndMethodName('foo', 'bar'),
+            ClassMethodVisibility::TYPE_PUBLIC,
+            false,
+            new FileOccurrence('foo.php', 1)
+        );
+
+        self::assertSame(['classes' => true], $resolver->getLayersForReference($classReference));
+        self::assertSame(['methods' => true], $resolver->getLayersForReference($methodReference));
+
+        self::assertTrue($resolver->isReferenceInLayer('methods', $methodReference));
+        self::assertFalse($resolver->isReferenceInLayer('classes', $methodReference));
+        self::assertTrue($resolver->isReferenceInLayer('classes', $classReference));
+        self::assertFalse($resolver->isReferenceInLayer('methods', $classReference));
+    }
+
+    public function testUnknownCollectorScopeIsRejected(): void
+    {
+        $resolver = new LayerResolver(
+            $this->buildCollectorResolverWithFakeCollector(),
+            [
+                [
+                    'name' => 'test',
+                    'collectors' => [
+                        [
+                            'type' => 'custom',
+                            'satisfy' => true,
+                            'scope' => 'nonsense',
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $this->expectException(InvalidCollectorDefinitionException::class);
+        $this->expectExceptionMessage('Unknown collector scope "nonsense". Available scopes: class, method.');
+
+        $resolver->has('test');
     }
 
     private function buildCollectorResolverWithFakeCollector(): CollectorResolverInterface

--- a/tests/Supportive/DependencyInjection/DeptracExtensionTest.php
+++ b/tests/Supportive/DependencyInjection/DeptracExtensionTest.php
@@ -419,6 +419,93 @@ final class DeptracExtensionTest extends TestCase
         );
     }
 
+    public function testMethodGranularityIsDisabledByDefault(): void
+    {
+        $this->extension->load([], $this->container);
+
+        self::assertFalse($this->container->getParameter('method_granularity'));
+    }
+
+    public function testMethodGranularityIsEnabledByTheMethodAnalyserType(): void
+    {
+        $configs = [
+            'deptrac' => [
+                'analyser' => [
+                    'types' => [EmitterType::CLASS_TOKEN->value, EmitterType::METHOD_TOKEN->value],
+                ] + self::ANALYSER_DEFAULTS,
+            ],
+        ];
+
+        $this->extension->load($configs, $this->container);
+
+        self::assertTrue($this->container->getParameter('method_granularity'));
+    }
+
+    public function testMethodGranularityIsEnabledByAMethodScopedCollector(): void
+    {
+        $configs = [
+            'deptrac' => [
+                'layers' => [
+                    [
+                        'name' => 'Application',
+                        'collectors' => [
+                            ['type' => 'attribute', 'value' => 'AsCommandHandler', 'scope' => 'method'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->extension->load($configs, $this->container);
+
+        self::assertTrue($this->container->getParameter('method_granularity'));
+    }
+
+    public function testMethodGranularityIsEnabledByANestedMethodScopedCollector(): void
+    {
+        $configs = [
+            'deptrac' => [
+                'layers' => [
+                    [
+                        'name' => 'Application',
+                        'collectors' => [
+                            [
+                                'type' => 'bool',
+                                'must' => [
+                                    ['type' => 'directory', 'value' => 'src/.*', 'scope' => 'method'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->extension->load($configs, $this->container);
+
+        self::assertTrue($this->container->getParameter('method_granularity'));
+    }
+
+    public function testMethodGranularityStaysDisabledForClassScopedCollectors(): void
+    {
+        $configs = [
+            'deptrac' => [
+                'layers' => [
+                    [
+                        'name' => 'Application',
+                        'collectors' => [
+                            ['type' => 'attribute', 'value' => 'AsCommandHandler'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->extension->load($configs, $this->container);
+
+        self::assertFalse($this->container->getParameter('method_granularity'));
+    }
+
     public function testIgnoreUncoveredInternalClasses(): void
     {
         $configs = [

--- a/tests/Supportive/OutputFormatter/ConsoleOutputFormatterTest.php
+++ b/tests/Supportive/OutputFormatter/ConsoleOutputFormatterTest.php
@@ -8,6 +8,7 @@ use Deptrac\Deptrac\Contract\Analyser\AnalysisResult;
 use Deptrac\Deptrac\Contract\Ast\AstMap\AstInherit;
 use Deptrac\Deptrac\Contract\Ast\AstMap\AstInheritType;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeToken;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodToken;
 use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyContext;
 use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyType;
 use Deptrac\Deptrac\Contract\Ast\AstMap\FileOccurrence;
@@ -111,6 +112,35 @@ final class ConsoleOutputFormatterTest extends TestCase
             'expectedOutput' => '
                 OriginalA must not depend on OriginalB (LayerA on LayerB)
                 originalA.php:12
+
+                Report:
+                Violations: 1
+                Skipped violations: 0
+                Uncovered: 0
+                Allowed: 0
+                Warnings:0
+                Errors:0
+            ',
+        ];
+
+        yield 'Method token violation' => [
+            'rules' => [
+                new Violation(
+                    new Dependency(
+                        ClassMethodToken::fromFQCNAndMethodName('App\RegisterBookFeature', 'handleRegister'),
+                        ClassMethodToken::fromFQCNAndMethodName('App\RegisterBookFeature', 'registerBook'),
+                        new DependencyContext(new FileOccurrence('RegisterBookFeature.php', 24), DependencyType::METHOD_CALL)
+                    ),
+                    'Application',
+                    'Infrastructure',
+                    new DummyViolationCreatingRule()
+                ),
+            ],
+            'errors' => [],
+            'warnings' => [],
+            'expectedOutput' => '
+                App\RegisterBookFeature::handleRegister() must not depend on App\RegisterBookFeature::registerBook() (Application on Infrastructure)
+                RegisterBookFeature.php:24
 
                 Report:
                 Violations: 1


### PR DESCRIPTION
That's a big pull request, I know, but it provides a feature which a lot of applications might benefit from!

**TL;DR**

These changes introduce an opt-in configuration which enables a single class method to belong to a different layer than its class. Collectors have an optional `scope: method` attribute (`->forMethods()` in the PHP config DSL), and a new opt-in `method` analyser type which tracks method calls as dependencies on the called method.

----

Currently, Deptrac assigns whole classes to layers. Vertical-slice architectures often co-locate code from several layers in one class, for example: a feature class combining an HTTP route handler (infrastructure) with a command/event handler (application). Obviously with the current layer analysis such class will end up in two layers and something like the following will not be possible:

```php
#[AsController]
class RegisterBookController
{
    #[Route(path: '/register', methods: ['POST'])]
    public function registerBook(#[MapRequestPayload] RegisterBookRequest $request, CommandBusInterface $commandBus): void
    {
        $command = new RegisterBookCommand(/* ... */);

        $commandBus->dispatch($command);
    }

    #[AsCommandHandler]
    public function registerBookHandler(
        RegisterBookCommand $command,
        BookRepositoryInterface $bookRepository,
    ): void {
        $book = new Book(/* $command->name, ... */);

        $bookRepository->add($book);
    }
}
```
Proposed Deptrac configuration:
```yaml
deptrac:
  analyser:
    types: [class, method]
  layers:
    - name: Infrastructure
      collectors:
        - { type: attribute, value: AsController }
    - name: Application
      collectors:
        - { type: attribute, value: AsCommandHandler, scope: method }
```

A method matched by a `scope: method` collector leaves its class's layers; everything declared inside it (parameter/return types, attributes, body) is checked against the method's layer. Unmatched methods keep belonging to their class, exactly as before.

Class methods are extracted as first-class AST references (`ClassMethodReference`) with their own dependencies, attributes and tags. Method dependencies are mirrored on the class so class-level analysis stays complete. Calls like `$this->`, `self::`, `static::` are emitted as `method_call` dependencies. With the PHPStan parser, cross-class instance calls are also resolved when the receiver type is statically known (typed properties, `new` expressions, return-type chains). Dependencies of inherited layered methods are flattened into the inheriting class, mirroring class-level flattening.

`scope: method` works with the `attribute`, `method`, `tagValueRegex`, `directory`, `glob` and `bool` collectors.

The functionality is completely opt-in, which is one of the reasons why so many files are modified. Analysis results, parse cost, AST cache size and cache contents are unchanged unless the config enables the `method` analyser type or a `scope: method` collector. Method extraction is gated on a container parameter derived from the config, and the AST cache version embeds the flag so toggling it invalidates stale entries automatically.
