### PR TITLE
feat: extract TokenResolverInterface as an extension point

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -9,6 +9,7 @@ use Deptrac\Deptrac\Contract\Ast\ParserInterface;
 use Deptrac\Deptrac\Contract\Ast\TypeResolverInterface;
 use Deptrac\Deptrac\Contract\Config\CollectorType;
 use Deptrac\Deptrac\Contract\Config\EmitterType;
+use Deptrac\Deptrac\Contract\Dependency\TokenResolverInterface;
 use Deptrac\Deptrac\Contract\Layer\CollectorResolverInterface;
 use Deptrac\Deptrac\Contract\Layer\LayerProviderInterface;
 use Deptrac\Deptrac\Contract\Layer\LayerResolverInterface;
@@ -23,6 +24,7 @@ use Deptrac\Deptrac\Core\Ast\AstLoader;
 use Deptrac\Deptrac\Core\Ast\AstMapExtractor;
 use Deptrac\Deptrac\Core\Ast\Parser\Cache\AstFileReferenceInMemoryCache;
 use Deptrac\Deptrac\Core\Ast\Parser\TypeResolver;
+use Deptrac\Deptrac\Core\Dependency\DelegatingTokenResolver;
 use Deptrac\Deptrac\Core\Dependency\DependencyResolver;
 use Deptrac\Deptrac\Core\Dependency\TokenResolver;
 use Deptrac\Deptrac\Core\InputCollector\FileInputCollector;
@@ -295,7 +297,19 @@ return static function (ContainerConfigurator $container): void {
             '$emitterLocator' => tagged_locator('dependency_emitter', 'key'),
         ])
     ;
-    $services->set(TokenResolver::class);
+    // Extensions add resolvers for their own token types by tagging them
+    // with 'token_resolver'; the default resolver runs last.
+    $services
+        ->set(TokenResolver::class)
+        ->tag('token_resolver', ['priority' => -256])
+    ;
+    $services
+        ->set(DelegatingTokenResolver::class)
+        ->args([
+            '$resolvers' => tagged_iterator('token_resolver'),
+        ])
+    ;
+    $services->alias(TokenResolverInterface::class, DelegatingTokenResolver::class);
     $services
         ->set(ClassDependencyEmitter::class)
         ->tag('dependency_emitter', ['key' => EmitterType::CLASS_TOKEN->value])

--- a/docs/extending_deptrac.md
+++ b/docs/extending_deptrac.md
@@ -52,6 +52,7 @@ To recap, the main extension points are:
 - `Ast\ReferenceExtractorInterface` to extract references from the AST
 - `Ast\ParserInterface` to replace the whole PHP parser
 - `Dependency\DependencyEmitterInterface` to transform references to dependencies
+- `Dependency\TokenResolverInterface` to resolve tokens to their references, e.g. to support custom token types
 - `Layer\CollectorInterface` to better define tokens that belong to a layer
 - Event subscribers to `Analyser\ProcessEvent` to decide whether a dependency is allowed or not
 - `OutputFormatter\OutputFormatterInterface` to customize how the results are displayed
@@ -193,6 +194,66 @@ return static function (DeptracConfig $config, ContainerConfigurator $containerC
     ;
 }
 ```
+
+## Token resolvers
+
+Every dependency connects two tokens (usually class names). Before layers can
+be assigned, each token has to be resolved to the reference that describes it
+in the AST map. This is done by the `Dependency\TokenResolverInterface`.
+
+Every token is offered to the registered resolvers in turn, and the first one
+that `supports()` it resolves it. The resolver shipped with Deptrac handles the
+built-in token types (class-like, function, file and superglobal tokens) and
+falls back to a bare reference when the AST map does not contain the token
+(e.g. classes defined outside of the analysed paths).
+
+If your extension introduces its own token type (for example emitted by a
+custom dependency emitter), add a resolver for it:
+
+```php
+final class CustomTokenResolver implements TokenResolverInterface
+{
+    public function supports(TokenInterface $token): bool
+    {
+        return $token instanceof CustomToken;
+    }
+
+    public function resolve(TokenInterface $token, AstMapInterface $astMap): TokenReferenceInterface
+    {
+        assert($token instanceof CustomToken);
+
+        return new CustomTokenReference($token /* , ... */);
+    }
+}
+```
+
+And register it in the `deptrac.php` file:
+
+```php
+return static function (DeptracConfig $config, ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services
+        ->set(CustomTokenResolver::class)
+        ->tag('token_resolver')
+    ;
+}
+```
+
+`resolve()` is only called for tokens your resolver reports as supported, so
+there is nothing to delegate: any token you do not claim is passed on to the
+next resolver. Several extensions can therefore each contribute their own token
+types without knowing about each other. The default resolver is registered with
+priority `-256` and runs last; pass an explicit `['priority' => N]` to the tag
+if you need to run before or after another extension, or to take over one of the
+built-in token types.
+
+A token that no resolver supports aborts the analysis with an
+`UnrecognizedTokenException`.
+
+Aliasing `TokenResolverInterface` to your own service is still possible, but it
+*replaces* the whole chain, including the default resolver and the resolvers of
+any other extension. Only do that if you really mean to take over token
+resolution completely.
 
 ## Layer collectors
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -1,3 +1,15 @@
+# Upgrade to 4.0
+
+### New extension points (no action required for most users)
+
+- `Contract\Dependency\TokenResolverInterface` was introduced; extensions can
+  register additional resolvers for their own token types with the
+  `token_resolver` tag. `Core\Dependency\TokenResolver` still handles the
+  built-in token types, but is now reached through
+  `Core\Dependency\DelegatingTokenResolver`, which is what
+  `TokenResolverInterface` is aliased to. The default resolver's `resolve()`
+  now accepts any `AstMapInterface` (previously the concrete `Core\Ast\AstMap`).
+
 # Upgrade from 1.0.2 to 2.0.0
 
 ### Dropped functionality

--- a/src/Contract/Dependency/TokenResolverInterface.php
+++ b/src/Contract/Dependency/TokenResolverInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deptrac\Deptrac\Contract\Dependency;
+
+use Deptrac\Deptrac\Contract\Ast\AstMap\AstMapInterface;
+use Deptrac\Deptrac\Contract\Ast\AstMap\TokenInterface;
+use Deptrac\Deptrac\Contract\Ast\AstMap\TokenReferenceInterface;
+
+/**
+ * Resolves a token to the reference describing it.
+ *
+ * Implementations are registered with the `token_resolver` tag and are asked
+ * in turn (highest tag priority first) whether they can resolve a given
+ * token, which lets several extensions each contribute their own token
+ * types. The default resolver knows the token types shipped by Deptrac and
+ * runs last.
+ */
+interface TokenResolverInterface
+{
+    /**
+     * Whether this resolver knows how to resolve the given token.
+     */
+    public function supports(TokenInterface $token): bool;
+
+    /**
+     * Only called with tokens this resolver {@see supports()}.
+     *
+     * @throws UnrecognizedTokenException when the token type is not recognized
+     */
+    public function resolve(TokenInterface $token, AstMapInterface $astMap): TokenReferenceInterface;
+}

--- a/src/Contract/Dependency/UnrecognizedTokenException.php
+++ b/src/Contract/Dependency/UnrecognizedTokenException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Deptrac\Deptrac\Core\Dependency;
+namespace Deptrac\Deptrac\Contract\Dependency;
 
 use Deptrac\Deptrac\Contract\Ast\AstMap\TokenInterface;
 use Deptrac\Deptrac\Contract\ExceptionInterface;

--- a/src/Core/Analyser/AnalyserException.php
+++ b/src/Core/Analyser/AnalyserException.php
@@ -6,12 +6,12 @@ namespace Deptrac\Deptrac\Core\Analyser;
 
 use Deptrac\Deptrac\Contract\Ast\AstException;
 use Deptrac\Deptrac\Contract\Ast\CouldNotParseFileException;
+use Deptrac\Deptrac\Contract\Dependency\UnrecognizedTokenException;
 use Deptrac\Deptrac\Contract\ExceptionInterface;
 use Deptrac\Deptrac\Contract\Layer\CircularReferenceException;
 use Deptrac\Deptrac\Contract\Layer\InvalidCollectorDefinitionException;
 use Deptrac\Deptrac\Contract\Layer\InvalidLayerDefinitionException;
 use Deptrac\Deptrac\Core\Dependency\InvalidEmitterConfigurationException;
-use Deptrac\Deptrac\Core\Dependency\UnrecognizedTokenException;
 use RuntimeException;
 
 final class AnalyserException extends RuntimeException implements ExceptionInterface

--- a/src/Core/Analyser/DependencyLayersAnalyser.php
+++ b/src/Core/Analyser/DependencyLayersAnalyser.php
@@ -10,6 +10,8 @@ use Deptrac\Deptrac\Contract\Analyser\PostProcessEvent;
 use Deptrac\Deptrac\Contract\Analyser\ProcessEvent;
 use Deptrac\Deptrac\Contract\Ast\AstException;
 use Deptrac\Deptrac\Contract\Ast\CouldNotParseFileException;
+use Deptrac\Deptrac\Contract\Dependency\TokenResolverInterface;
+use Deptrac\Deptrac\Contract\Dependency\UnrecognizedTokenException;
 use Deptrac\Deptrac\Contract\Layer\InvalidCollectorDefinitionException;
 use Deptrac\Deptrac\Contract\Layer\InvalidLayerDefinitionException;
 use Deptrac\Deptrac\Contract\Layer\LayerResolverInterface;
@@ -17,8 +19,6 @@ use Deptrac\Deptrac\Contract\Result\Warning;
 use Deptrac\Deptrac\Core\Ast\AstMapExtractor;
 use Deptrac\Deptrac\Core\Dependency\DependencyResolver;
 use Deptrac\Deptrac\Core\Dependency\InvalidEmitterConfigurationException;
-use Deptrac\Deptrac\Core\Dependency\TokenResolver;
-use Deptrac\Deptrac\Core\Dependency\UnrecognizedTokenException;
 use Psr\EventDispatcher\EventDispatcherInterface;
 
 use function count;
@@ -28,7 +28,7 @@ class DependencyLayersAnalyser
     public function __construct(
         private readonly AstMapExtractor $astMapExtractor,
         private readonly DependencyResolver $dependencyResolver,
-        private readonly TokenResolver $tokenResolver,
+        private readonly TokenResolverInterface $tokenResolver,
         private readonly LayerResolverInterface $layerResolver,
         private readonly EventDispatcherInterface $eventDispatcher,
     ) {}

--- a/src/Core/Analyser/LayerDependenciesAnalyser.php
+++ b/src/Core/Analyser/LayerDependenciesAnalyser.php
@@ -6,6 +6,8 @@ namespace Deptrac\Deptrac\Core\Analyser;
 
 use Deptrac\Deptrac\Contract\Ast\AstException;
 use Deptrac\Deptrac\Contract\Ast\CouldNotParseFileException;
+use Deptrac\Deptrac\Contract\Dependency\TokenResolverInterface;
+use Deptrac\Deptrac\Contract\Dependency\UnrecognizedTokenException;
 use Deptrac\Deptrac\Contract\Layer\InvalidCollectorDefinitionException;
 use Deptrac\Deptrac\Contract\Layer\InvalidLayerDefinitionException;
 use Deptrac\Deptrac\Contract\Layer\LayerResolverInterface;
@@ -13,14 +15,12 @@ use Deptrac\Deptrac\Contract\Result\Uncovered;
 use Deptrac\Deptrac\Core\Ast\AstMapExtractor;
 use Deptrac\Deptrac\Core\Dependency\DependencyResolver;
 use Deptrac\Deptrac\Core\Dependency\InvalidEmitterConfigurationException;
-use Deptrac\Deptrac\Core\Dependency\TokenResolver;
-use Deptrac\Deptrac\Core\Dependency\UnrecognizedTokenException;
 
 class LayerDependenciesAnalyser
 {
     public function __construct(
         private readonly AstMapExtractor $astMapExtractor,
-        private readonly TokenResolver $tokenResolver,
+        private readonly TokenResolverInterface $tokenResolver,
         private readonly DependencyResolver $dependencyResolver,
         private readonly LayerResolverInterface $layerResolver,
     ) {}

--- a/src/Core/Analyser/LayerForTokenAnalyser.php
+++ b/src/Core/Analyser/LayerForTokenAnalyser.php
@@ -7,13 +7,13 @@ namespace Deptrac\Deptrac\Core\Analyser;
 use Deptrac\Deptrac\Contract\Ast\AstException;
 use Deptrac\Deptrac\Contract\Ast\AstMap\TokenReferenceInterface;
 use Deptrac\Deptrac\Contract\Ast\CouldNotParseFileException;
+use Deptrac\Deptrac\Contract\Dependency\TokenResolverInterface;
+use Deptrac\Deptrac\Contract\Dependency\UnrecognizedTokenException;
 use Deptrac\Deptrac\Contract\Layer\InvalidCollectorDefinitionException;
 use Deptrac\Deptrac\Contract\Layer\InvalidLayerDefinitionException;
 use Deptrac\Deptrac\Contract\Layer\LayerResolverInterface;
 use Deptrac\Deptrac\Core\Ast\AstMap;
 use Deptrac\Deptrac\Core\Ast\AstMapExtractor;
-use Deptrac\Deptrac\Core\Dependency\TokenResolver;
-use Deptrac\Deptrac\Core\Dependency\UnrecognizedTokenException;
 
 use function array_values;
 use function ksort;
@@ -24,7 +24,7 @@ class LayerForTokenAnalyser
 {
     public function __construct(
         private readonly AstMapExtractor $astMapExtractor,
-        private readonly TokenResolver $tokenResolver,
+        private readonly TokenResolverInterface $tokenResolver,
         private readonly LayerResolverInterface $layerResolver,
     ) {}
 

--- a/src/Core/Analyser/RulesetUsageAnalyser.php
+++ b/src/Core/Analyser/RulesetUsageAnalyser.php
@@ -6,6 +6,8 @@ namespace Deptrac\Deptrac\Core\Analyser;
 
 use Deptrac\Deptrac\Contract\Ast\AstException;
 use Deptrac\Deptrac\Contract\Ast\CouldNotParseFileException;
+use Deptrac\Deptrac\Contract\Dependency\TokenResolverInterface;
+use Deptrac\Deptrac\Contract\Dependency\UnrecognizedTokenException;
 use Deptrac\Deptrac\Contract\Layer\CircularReferenceException;
 use Deptrac\Deptrac\Contract\Layer\InvalidCollectorDefinitionException;
 use Deptrac\Deptrac\Contract\Layer\InvalidLayerDefinitionException;
@@ -13,8 +15,6 @@ use Deptrac\Deptrac\Contract\Layer\LayerResolverInterface;
 use Deptrac\Deptrac\Core\Ast\AstMapExtractor;
 use Deptrac\Deptrac\Core\Dependency\DependencyResolver;
 use Deptrac\Deptrac\Core\Dependency\InvalidEmitterConfigurationException;
-use Deptrac\Deptrac\Core\Dependency\TokenResolver;
-use Deptrac\Deptrac\Core\Dependency\UnrecognizedTokenException;
 use Deptrac\Deptrac\Core\Layer\LayerProvider;
 
 class RulesetUsageAnalyser
@@ -27,7 +27,7 @@ class RulesetUsageAnalyser
         private readonly LayerResolverInterface $layerResolver,
         private readonly AstMapExtractor $astMapExtractor,
         private readonly DependencyResolver $dependencyResolver,
-        private readonly TokenResolver $tokenResolver,
+        private readonly TokenResolverInterface $tokenResolver,
         private readonly array $layers,
     ) {}
 

--- a/src/Core/Analyser/TokenInLayerAnalyser.php
+++ b/src/Core/Analyser/TokenInLayerAnalyser.php
@@ -7,12 +7,12 @@ namespace Deptrac\Deptrac\Core\Analyser;
 use Deptrac\Deptrac\Contract\Ast\AstException;
 use Deptrac\Deptrac\Contract\Ast\CouldNotParseFileException;
 use Deptrac\Deptrac\Contract\Config\EmitterType;
+use Deptrac\Deptrac\Contract\Dependency\TokenResolverInterface;
+use Deptrac\Deptrac\Contract\Dependency\UnrecognizedTokenException;
 use Deptrac\Deptrac\Contract\Layer\InvalidCollectorDefinitionException;
 use Deptrac\Deptrac\Contract\Layer\InvalidLayerDefinitionException;
 use Deptrac\Deptrac\Contract\Layer\LayerResolverInterface;
 use Deptrac\Deptrac\Core\Ast\AstMapExtractor;
-use Deptrac\Deptrac\Core\Dependency\TokenResolver;
-use Deptrac\Deptrac\Core\Dependency\UnrecognizedTokenException;
 
 use function array_values;
 use function in_array;
@@ -29,7 +29,7 @@ class TokenInLayerAnalyser
      */
     public function __construct(
         private readonly AstMapExtractor $astMapExtractor,
-        private readonly TokenResolver $tokenResolver,
+        private readonly TokenResolverInterface $tokenResolver,
         private readonly LayerResolverInterface $layerResolver,
         array $config,
     ) {

--- a/src/Core/Analyser/UnassignedTokenAnalyser.php
+++ b/src/Core/Analyser/UnassignedTokenAnalyser.php
@@ -7,12 +7,12 @@ namespace Deptrac\Deptrac\Core\Analyser;
 use Deptrac\Deptrac\Contract\Ast\AstException;
 use Deptrac\Deptrac\Contract\Ast\CouldNotParseFileException;
 use Deptrac\Deptrac\Contract\Config\EmitterType;
+use Deptrac\Deptrac\Contract\Dependency\TokenResolverInterface;
+use Deptrac\Deptrac\Contract\Dependency\UnrecognizedTokenException;
 use Deptrac\Deptrac\Contract\Layer\InvalidCollectorDefinitionException;
 use Deptrac\Deptrac\Contract\Layer\InvalidLayerDefinitionException;
 use Deptrac\Deptrac\Contract\Layer\LayerResolverInterface;
 use Deptrac\Deptrac\Core\Ast\AstMapExtractor;
-use Deptrac\Deptrac\Core\Dependency\TokenResolver;
-use Deptrac\Deptrac\Core\Dependency\UnrecognizedTokenException;
 
 use function array_values;
 use function natcasesort;
@@ -29,7 +29,7 @@ class UnassignedTokenAnalyser
      */
     public function __construct(
         private readonly AstMapExtractor $astMapExtractor,
-        private readonly TokenResolver $tokenResolver,
+        private readonly TokenResolverInterface $tokenResolver,
         private readonly LayerResolverInterface $layerResolver,
         array $config,
     ) {

--- a/src/Core/Dependency/DelegatingTokenResolver.php
+++ b/src/Core/Dependency/DelegatingTokenResolver.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deptrac\Deptrac\Core\Dependency;
+
+use Deptrac\Deptrac\Contract\Ast\AstMap\AstMapInterface;
+use Deptrac\Deptrac\Contract\Ast\AstMap\TokenInterface;
+use Deptrac\Deptrac\Contract\Ast\AstMap\TokenReferenceInterface;
+use Deptrac\Deptrac\Contract\Dependency\TokenResolverInterface;
+use Deptrac\Deptrac\Contract\Dependency\UnrecognizedTokenException;
+
+use function iterator_to_array;
+
+/**
+ * Hands a token to the first registered resolver that supports it.
+ *
+ * Resolvers are collected from the `token_resolver` tag, ordered by tag
+ * priority, with the default {@see TokenResolver} running last. Extensions
+ * that introduce their own token types add a resolver for them instead of
+ * replacing the existing ones.
+ */
+final class DelegatingTokenResolver implements TokenResolverInterface
+{
+    /** @var list<TokenResolverInterface> */
+    private readonly array $resolvers;
+
+    /**
+     * @param iterable<TokenResolverInterface> $resolvers
+     */
+    public function __construct(iterable $resolvers)
+    {
+        $this->resolvers = iterator_to_array($resolvers, false);
+    }
+
+    public function supports(TokenInterface $token): bool
+    {
+        foreach ($this->resolvers as $resolver) {
+            if ($resolver->supports($token)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @throws UnrecognizedTokenException
+     */
+    public function resolve(TokenInterface $token, AstMapInterface $astMap): TokenReferenceInterface
+    {
+        foreach ($this->resolvers as $resolver) {
+            if ($resolver->supports($token)) {
+                return $resolver->resolve($token, $astMap);
+            }
+        }
+
+        throw UnrecognizedTokenException::cannotCreateReference($token);
+    }
+}

--- a/src/Core/Dependency/TokenResolver.php
+++ b/src/Core/Dependency/TokenResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Deptrac\Deptrac\Core\Dependency;
 
+use Deptrac\Deptrac\Contract\Ast\AstMap\AstMapInterface;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeReference;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeToken;
 use Deptrac\Deptrac\Contract\Ast\AstMap\FileReference;
@@ -14,20 +15,29 @@ use Deptrac\Deptrac\Contract\Ast\AstMap\SuperGlobalToken;
 use Deptrac\Deptrac\Contract\Ast\AstMap\TokenInterface;
 use Deptrac\Deptrac\Contract\Ast\AstMap\TokenReferenceInterface;
 use Deptrac\Deptrac\Contract\Ast\AstMap\VariableReference;
-use Deptrac\Deptrac\Core\Ast\AstMap;
+use Deptrac\Deptrac\Contract\Dependency\TokenResolverInterface;
+use Deptrac\Deptrac\Contract\Dependency\UnrecognizedTokenException;
 
-class TokenResolver
+class TokenResolver implements TokenResolverInterface
 {
+    public function supports(TokenInterface $token): bool
+    {
+        return $token instanceof ClassLikeToken
+            || $token instanceof FunctionToken
+            || $token instanceof SuperGlobalToken
+            || $token instanceof FileToken;
+    }
+
     /**
      * @throws UnrecognizedTokenException
      */
-    public function resolve(TokenInterface $token, AstMap $astMap): TokenReferenceInterface
+    public function resolve(TokenInterface $token, AstMapInterface $astMap): TokenReferenceInterface
     {
         return match (true) {
-            $token instanceof ClassLikeToken => $astMap->getClassReferenceForToken($token) ?? new ClassLikeReference($token),
+            $token instanceof ClassLikeToken => $astMap->getClassLikeReferences()[$token->toString()] ?? new ClassLikeReference($token),
             $token instanceof FunctionToken => $astMap->getFunctionReferenceForToken($token) ?? new FunctionReference($token),
             $token instanceof SuperGlobalToken => new VariableReference($token),
-            $token instanceof FileToken => $astMap->getFileReferenceForToken($token) ?? new FileReference($token->path, [], [], []),
+            $token instanceof FileToken => $astMap->getFileReferences()[$token->toString()] ?? new FileReference($token->path, [], [], []),
             default => throw UnrecognizedTokenException::cannotCreateReference($token),
         };
     }

--- a/tests/Core/Dependency/DelegatingTokenResolverTest.php
+++ b/tests/Core/Dependency/DelegatingTokenResolverTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Deptrac\Deptrac\Core\Dependency;
+
+use Deptrac\Deptrac\Contract\Ast\AstMap\AstMapInterface;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeReference;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeToken;
+use Deptrac\Deptrac\Contract\Ast\AstMap\TokenInterface;
+use Deptrac\Deptrac\Contract\Ast\AstMap\TokenReferenceInterface;
+use Deptrac\Deptrac\Contract\Dependency\TokenResolverInterface;
+use Deptrac\Deptrac\Contract\Dependency\UnrecognizedTokenException;
+use Deptrac\Deptrac\Core\Ast\AstMap;
+use Deptrac\Deptrac\Core\Dependency\DelegatingTokenResolver;
+use Deptrac\Deptrac\Core\Dependency\TokenResolver;
+use PHPUnit\Framework\TestCase;
+
+final class DelegatingTokenResolverTest extends TestCase
+{
+    public function testDelegatesToTheFirstSupportingResolver(): void
+    {
+        $resolver = new DelegatingTokenResolver([
+            self::resolverFor(CustomTokenA::class, 'first'),
+            self::resolverFor(CustomTokenA::class, 'second'),
+            new TokenResolver(),
+        ]);
+
+        $resolved = $resolver->resolve(new CustomTokenA(), new AstMap([]));
+
+        self::assertSame('first', $resolved->getToken()->toString());
+    }
+
+    public function testResolversOfDifferentExtensionsCoexist(): void
+    {
+        $resolver = new DelegatingTokenResolver([
+            self::resolverFor(CustomTokenA::class, 'from-a'),
+            self::resolverFor(CustomTokenB::class, 'from-b'),
+            new TokenResolver(),
+        ]);
+        $astMap = new AstMap([]);
+
+        self::assertSame('from-a', $resolver->resolve(new CustomTokenA(), $astMap)->getToken()->toString());
+        self::assertSame('from-b', $resolver->resolve(new CustomTokenB(), $astMap)->getToken()->toString());
+        self::assertSame(
+            'App\\Foo',
+            $resolver->resolve(ClassLikeToken::fromFQCN('App\\Foo'), $astMap)->getToken()->toString()
+        );
+    }
+
+    public function testSupportsIsDelegatedToTheRegisteredResolvers(): void
+    {
+        $resolver = new DelegatingTokenResolver([self::resolverFor(CustomTokenA::class, 'from-a')]);
+
+        self::assertTrue($resolver->supports(new CustomTokenA()));
+        self::assertFalse($resolver->supports(new CustomTokenB()));
+    }
+
+    public function testThrowsWhenNoResolverSupportsTheToken(): void
+    {
+        $resolver = new DelegatingTokenResolver([new TokenResolver()]);
+
+        $this->expectException(UnrecognizedTokenException::class);
+
+        $resolver->resolve(new CustomTokenA(), new AstMap([]));
+    }
+
+    /**
+     * @param class-string<TokenInterface> $tokenType
+     */
+    private static function resolverFor(string $tokenType, string $resolvedName): TokenResolverInterface
+    {
+        return new class($tokenType, $resolvedName) implements TokenResolverInterface {
+            /**
+             * @param class-string<TokenInterface> $tokenType
+             */
+            public function __construct(
+                private readonly string $tokenType,
+                private readonly string $resolvedName,
+            ) {}
+
+            public function supports(TokenInterface $token): bool
+            {
+                return $token instanceof $this->tokenType;
+            }
+
+            public function resolve(TokenInterface $token, AstMapInterface $astMap): TokenReferenceInterface
+            {
+                return new ClassLikeReference(ClassLikeToken::fromFQCN($this->resolvedName));
+            }
+        };
+    }
+}
+
+final class CustomTokenA implements TokenInterface
+{
+    public function toString(): string
+    {
+        return 'custom-token-a';
+    }
+
+    public function equals(TokenInterface $token): bool
+    {
+        return $token instanceof self;
+    }
+}
+
+final class CustomTokenB implements TokenInterface
+{
+    public function toString(): string
+    {
+        return 'custom-token-b';
+    }
+
+    public function equals(TokenInterface $token): bool
+    {
+        return $token instanceof self;
+    }
+}

--- a/tests/Supportive/DependencyInjection/CustomToken.php
+++ b/tests/Supportive/DependencyInjection/CustomToken.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Deptrac\Deptrac\Supportive\DependencyInjection;
+
+use Deptrac\Deptrac\Contract\Ast\AstMap\TokenInterface;
+
+final class CustomToken implements TokenInterface
+{
+    public function toString(): string
+    {
+        return 'CustomToken';
+    }
+
+    public function equals(TokenInterface $token): bool
+    {
+        return $token instanceof self;
+    }
+}

--- a/tests/Supportive/DependencyInjection/CustomTokenResolver.php
+++ b/tests/Supportive/DependencyInjection/CustomTokenResolver.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Deptrac\Deptrac\Supportive\DependencyInjection;
+
+use Deptrac\Deptrac\Contract\Ast\AstMap\AstMapInterface;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeReference;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeToken;
+use Deptrac\Deptrac\Contract\Ast\AstMap\TokenInterface;
+use Deptrac\Deptrac\Contract\Ast\AstMap\TokenReferenceInterface;
+use Deptrac\Deptrac\Contract\Dependency\TokenResolverInterface;
+
+final class CustomTokenResolver implements TokenResolverInterface
+{
+    public function supports(TokenInterface $token): bool
+    {
+        return $token instanceof CustomToken;
+    }
+
+    public function resolve(TokenInterface $token, AstMapInterface $astMap): TokenReferenceInterface
+    {
+        return new ClassLikeReference(ClassLikeToken::fromFQCN($token->toString()));
+    }
+}

--- a/tests/Supportive/DependencyInjection/ServiceContainerBuilderTest.php
+++ b/tests/Supportive/DependencyInjection/ServiceContainerBuilderTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Tests\Deptrac\Deptrac\Supportive\DependencyInjection;
 
 use Deptrac\Deptrac\Contract\Ast\ParserInterface;
+use Deptrac\Deptrac\Core\Ast\AstMap;
+use Deptrac\Deptrac\Core\Dependency\DelegatingTokenResolver;
 use Deptrac\Deptrac\Supportive\DependencyInjection\ServiceContainerBuilder;
 use PHPUnit\Framework\TestCase;
 
@@ -18,6 +20,13 @@ final class ServiceContainerBuilderTest extends TestCase
 
         // test service override is possible
         self::assertSame(CustomPhpParser::class, $container->getDefinition(ParserInterface::class)->getClass());
+        // test contributing an additional token resolver is possible
+        $tokenResolver = $container->get('test.token_resolver');
+        self::assertInstanceOf(DelegatingTokenResolver::class, $tokenResolver);
+        self::assertSame(
+            'CustomToken',
+            $tokenResolver->resolve(new CustomToken(), new AstMap([]))->getToken()->toString()
+        );
 
         self::assertTrue($container->getParameter('ignore_uncovered_internal_classes'));
         self::assertSame(

--- a/tests/Supportive/DependencyInjection/config/custom.yaml
+++ b/tests/Supportive/DependencyInjection/config/custom.yaml
@@ -1,3 +1,9 @@
 services:
   Deptrac\Deptrac\Contract\Ast\ParserInterface:
     class: Tests\Deptrac\Deptrac\Supportive\DependencyInjection\CustomPhpParser
+  Tests\Deptrac\Deptrac\Supportive\DependencyInjection\CustomTokenResolver:
+    tags: ['token_resolver']
+  # public handle so the test can assert on the resolver actually wired in
+  test.token_resolver:
+    alias: Deptrac\Deptrac\Contract\Dependency\TokenResolverInterface
+    public: true


### PR DESCRIPTION
Fixes: #1558

The new `Contract\Dependency\TokenResolverInterface` pairs `resolve()` with a `supports()` predicate, and resolvers are collected from the `'token_resolver'` tag by `Core\Dependency\DelegatingTokenResolver`, which hands each token to the first resolver that claims it. 

The interface is aliased to that delegating resolver and all analysers depend on the interface. The default resolver keeps handling the built-in token types and is registered last (priority -256).

Extensions therefore *add* a resolver for their own token types instead of replacing the existing one, which is what the tagged extension points for reference extractors, dependency emitters and collectors already do. Two extensions can each contribute their token types without knowing about each other, with a single replaceable resolver, the one registered last would silently win and the other extension's tokens would abort the analysis with an UnrecognizedTokenException.

The default resolver now performs its lookups through `AstMapInterface` (identical key semantics).