### PR TITLE
feat: make the AST cache extensible

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -22,6 +22,9 @@ return static function (ContainerConfigurator $container): void {
     $services
         ->set(AstFileReferenceFileCache::class)
         ->args(['%cache_file%', DeptracVersion::get()])
+        // replaced with the version salts collected from services tagged
+        // 'ast_cache.version_salt', see AstCacheVersionSaltsPass
+        ->arg('$cacheVersionSalt', '')
     ;
 
     $services->alias(AstFileReferenceDeferredCacheInterface::class, AstFileReferenceFileCache::class);

--- a/docs/extending_deptrac.md
+++ b/docs/extending_deptrac.md
@@ -129,6 +129,57 @@ return static function (DeptracConfig $config, ContainerConfigurator $containerC
 }
 ```
 
+### Custom extractors and the AST cache
+
+The references found in a file are cached (see `cache_file`) and restored via
+`unserialize()` with a fixed allowlist of deptrac's own classes — for security
+reasons extension-defined classes are never unserialized. Keep two things in
+mind when your extractor is registered:
+
+- If your extractor records custom tokens, record them as
+  `Deptrac\Deptrac\Contract\Ast\AstMap\CustomToken`. It carries a
+  vendor-namespaced type tag and a payload of plain data (scalars, `null` and
+  arrays thereof), so the cache can restore it safely; rebuild richer value
+  objects from the payload at analysis time, e.g. in your
+  `TokenResolverInterface` or `DependencyEmitterInterface` implementation.
+  Tokens of any other class are not restored: the affected cache entries are
+  discarded and those files re-parsed on every run.
+
+  ```php
+  $referenceBuilder->dependency(
+      new CustomToken(
+          'acme/my-extension.route',
+          ['path' => $path, 'method' => $method],
+          sprintf('route:%s %s', $method, $path),
+      ),
+      $node->getLine(),
+      DependencyType::USE,
+  );
+  ```
+
+- References are cached per file and only refreshed when the file changes.
+  Entries written *before* your extractor was registered do not contain its
+  references. Contribute a version salt unique to your extension (e.g. its
+  name and version) by tagging one of your registered services — typically
+  the extractor that records the cached references — with
+  `ast_cache.version_salt`, so that enabling/disabling or upgrading your
+  extension invalidates previously written caches:
+
+  ```php
+  return static function (DeptracConfig $config, ContainerConfigurator $containerConfigurator): void {
+      $services = $containerConfigurator->services();
+      $services->set(CustomExtractor::class)
+          ->tag('reference_extractors')
+          ->tag('ast_cache.version_salt', ['salt' => 'my-extension@1.0.0'])
+      ;
+  }
+  ```
+
+  Every extension contributes its own salt this way: the tagged salts are
+  deduplicated, sorted and composed into a single cache version component,
+  so the result is deterministic, independent of registration order, and no
+  extension (or user) can overwrite another extension's salt.
+
 ## AST Parser
 
 It may be the case that the current AST parser implementation using Nikic PHP

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -10,6 +10,19 @@
   `TokenResolverInterface` is aliased to. The default resolver's `resolve()`
   now accepts any `AstMapInterface` (previously the concrete `Core\Ast\AstMap`).
 
+- Extensions can record custom tokens as the new data-only
+  `Deptrac\Deptrac\Contract\Ast\AstMap\CustomToken`, which the AST cache
+  restores without unserializing extension-defined classes, and can
+  contribute a cache version salt by tagging one of their services with
+  `ast_cache.version_salt` to invalidate caches written without them. Cache
+  entries that cannot be restored are now discarded (and re-parsed) instead
+  of crashing.
+
+### Possible BC impact
+
+- The AST cache layout version changed; existing caches are invalidated once
+  and rebuilt on the next run.
+
 # Upgrade from 1.0.2 to 2.0.0
 
 ### Dropped functionality

--- a/src/Contract/Ast/AstMap/CustomToken.php
+++ b/src/Contract/Ast/AstMap/CustomToken.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deptrac\Deptrac\Contract\Ast\AstMap;
+
+use InvalidArgumentException;
+
+use function get_debug_type;
+use function is_scalar;
+use function sprintf;
+
+/**
+ * Token for references recorded by third-party extractors.
+ *
+ * It carries plain data only - scalars, null and arrays thereof - so the AST
+ * cache can restore it without ever unserializing extension-defined classes.
+ * Extensions identify their tokens by a vendor-namespaced $type (e.g.
+ * "acme/my-extension.route") and rebuild richer value objects from $payload
+ * at analysis time.
+ *
+ * @psalm-immutable
+ */
+final class CustomToken implements TokenInterface
+{
+    /**
+     * @param string $type vendor-namespaced tag identifying the kind of token
+     * @param array<array-key, mixed> $payload scalars, null and arrays thereof only
+     * @param string $display human readable representation, used in reports
+     *
+     * @throws InvalidArgumentException when the payload contains anything but scalars, null and arrays thereof
+     */
+    public function __construct(
+        public readonly string $type,
+        public readonly array $payload,
+        private readonly string $display,
+    ) {
+        self::ensureDataOnly($payload);
+    }
+
+    public function toString(): string
+    {
+        return $this->display;
+    }
+
+    public function equals(TokenInterface $token): bool
+    {
+        return $token instanceof self
+            && $this->type === $token->type
+            && $this->payload === $token->payload;
+    }
+
+    /**
+     * unserialize() bypasses the constructor, so re-check the invariant when
+     * an instance is restored from the AST cache; a throwing __wakeup() makes
+     * the cache discard the entry.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function __wakeup(): void
+    {
+        self::ensureDataOnly($this->payload);
+    }
+
+    /**
+     * @param array<array-key, mixed> $payload
+     *
+     * @throws InvalidArgumentException
+     */
+    private static function ensureDataOnly(array $payload): void
+    {
+        array_walk_recursive(
+            $payload,
+            static function (mixed $value): void {
+                if (null !== $value && !is_scalar($value)) {
+                    throw new InvalidArgumentException(sprintf('CustomToken payloads may only contain scalars, null and arrays thereof, %s given.', get_debug_type($value)));
+                }
+            }
+        );
+    }
+}

--- a/src/Core/Ast/Parser/Cache/AstFileReferenceFileCache.php
+++ b/src/Core/Ast/Parser/Cache/AstFileReferenceFileCache.php
@@ -8,6 +8,7 @@ use Deptrac\Deptrac\Contract\Ast\AstMap\AstInherit;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeReference;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeToken;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeType;
+use Deptrac\Deptrac\Contract\Ast\AstMap\CustomToken;
 use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyContext;
 use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyToken;
 use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyType;
@@ -21,10 +22,10 @@ use Deptrac\Deptrac\Contract\Ast\AstMap\VariableReference;
 use Deptrac\Deptrac\Supportive\File\Exception\CouldNotReadFileException;
 use Deptrac\Deptrac\Supportive\File\Exception\FileNotExistsException;
 use Deptrac\Deptrac\Supportive\File\FileReader;
+use Throwable;
 
 use function array_filter;
 use function array_map;
-use function assert;
 use function dirname;
 use function file_exists;
 use function is_readable;
@@ -37,13 +38,34 @@ use function unserialize;
 
 class AstFileReferenceFileCache implements AstFileReferenceDeferredCacheInterface
 {
+    /**
+     * Internal cache layout version, independent of the deptrac release
+     * version. Bump whenever the serialized shape of the cached references
+     * changes within a release cycle.
+     */
+    private const SCHEMA_VERSION = '2';
+
     /** @var array<string, array{hash: string, reference: FileReference}> */
     private array $cache = [];
     private bool $loaded = false;
     /** @var array<string, bool> */
     private array $parsedFiles = [];
 
-    public function __construct(private readonly string $cacheFile, private readonly string $cacheVersion) {}
+    private readonly string $cacheVersion;
+
+    /**
+     * @param string $cacheVersionSalt salts of the extensions that change what
+     *                                 gets cached, composed from the services tagged
+     *                                 'ast_cache.version_salt' so extension (de)activation
+     *                                 invalidates existing caches
+     */
+    public function __construct(
+        private readonly string $cacheFile,
+        string $cacheVersion,
+        string $cacheVersionSalt = '',
+    ) {
+        $this->cacheVersion = $cacheVersion.'@'.self::SCHEMA_VERSION.('' !== $cacheVersionSalt ? '@'.$cacheVersionSalt : '');
+    }
 
     public function get(string $filepath): ?FileReference
     {
@@ -102,31 +124,46 @@ class AstFileReferenceFileCache implements AstFileReferenceDeferredCacheInterfac
             return;
         }
 
-        $this->cache = array_map(
+        $entries = array_map(
             /** @param array{hash: string, reference: string} $data */
-            static function (array $data): array {
-                $reference = unserialize(
-                    $data['reference'],
-                    [
-                        'allowed_classes' => [
-                            FileReference::class,
-                            ClassLikeReference::class,
-                            FunctionReference::class,
-                            VariableReference::class,
-                            AstInherit::class,
-                            DependencyToken::class,
-                            DependencyType::class,
-                            FileToken::class,
-                            ClassLikeToken::class,
-                            ClassLikeType::class,
-                            FunctionToken::class,
-                            SuperGlobalToken::class,
-                            FileOccurrence::class,
-                            DependencyContext::class,
-                        ],
-                    ]
-                );
-                assert($reference instanceof FileReference);
+            static function (array $data): ?array {
+                try {
+                    $reference = unserialize(
+                        $data['reference'],
+                        [
+                            'allowed_classes' => [
+                                FileReference::class,
+                                ClassLikeReference::class,
+                                FunctionReference::class,
+                                VariableReference::class,
+                                AstInherit::class,
+                                DependencyToken::class,
+                                DependencyType::class,
+                                FileToken::class,
+                                ClassLikeToken::class,
+                                ClassLikeType::class,
+                                CustomToken::class,
+                                FunctionToken::class,
+                                SuperGlobalToken::class,
+                                FileOccurrence::class,
+                                DependencyContext::class,
+                            ],
+                        ]
+                    );
+                    // @phpstan-ignore catch.neverThrown (unserialize() throws a TypeError when it assigns __PHP_Incomplete_Class to a typed property, CustomToken::__wakeup() throws on invalid payloads)
+                } catch (Throwable) {
+                    // the entry cannot be restored: it contains classes
+                    // outside of the allowlist (unserialize() throws a
+                    // TypeError when it assigns __PHP_Incomplete_Class to a
+                    // typed property) or otherwise invalid state (e.g. a
+                    // CustomToken payload rejected by __wakeup()): treat it
+                    // as a cache miss
+                    return null;
+                }
+
+                if (!$reference instanceof FileReference) {
+                    return null;
+                }
 
                 return [
                     'hash' => $data['hash'],
@@ -135,6 +172,8 @@ class AstFileReferenceFileCache implements AstFileReferenceDeferredCacheInterfac
             },
             $cache['payload']
         );
+
+        $this->cache = array_filter($entries);
     }
 
     public function write(): void

--- a/src/Supportive/DependencyInjection/AstCacheVersionSaltsPass.php
+++ b/src/Supportive/DependencyInjection/AstCacheVersionSaltsPass.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deptrac\Deptrac\Supportive\DependencyInjection;
+
+use Deptrac\Deptrac\Contract\Ast\AstFileReferenceCacheInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+
+use function array_key_exists;
+use function array_unique;
+use function implode;
+use function is_string;
+use function sort;
+use function sprintf;
+
+/**
+ * Composes the AST cache version salt from all services tagged with
+ * 'ast_cache.version_salt'.
+ *
+ * Every extension contributes its own salt by tagging one of its registered
+ * services; the salts are deduplicated and sorted, so the composed value is
+ * deterministic and independent of registration order. Registering or
+ * removing a salt changes the composed value and thereby invalidates caches
+ * written without it.
+ */
+final class AstCacheVersionSaltsPass implements CompilerPassInterface
+{
+    public const TAG_NAME = 'ast_cache.version_salt';
+
+    /**
+     * Named constructor argument of the file-backed AST cache carrying the
+     * composed salts; declared by name in cache.php so this pass does not
+     * depend on the argument's position. Named arguments are resolved to
+     * positions during optimization, after this pass has run.
+     */
+    private const SALT_ARGUMENT = '$cacheVersionSalt';
+
+    /**
+     * @throws InvalidArgumentException when a tag has no non-empty "salt" attribute
+     * @throws OutOfBoundsException
+     * @throws ServiceNotFoundException
+     */
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->has(AstFileReferenceCacheInterface::class)) {
+            return;
+        }
+
+        // resolves to the file-backed cache when caching is enabled (see
+        // cache.php) and to the in-memory cache otherwise; only the
+        // file-backed cache persists between runs and declares the salt
+        // argument
+        $cache = $container->findDefinition(AstFileReferenceCacheInterface::class);
+
+        if (!array_key_exists(self::SALT_ARGUMENT, $cache->getArguments())) {
+            return;
+        }
+
+        $salts = [];
+
+        /** @var array<string, list<array<string, mixed>>> $taggedServices */
+        $taggedServices = $container->findTaggedServiceIds(self::TAG_NAME);
+
+        foreach ($taggedServices as $serviceId => $tags) {
+            foreach ($tags as $attributes) {
+                $salt = $attributes['salt'] ?? null;
+
+                if (!is_string($salt) || '' === $salt) {
+                    throw new InvalidArgumentException(sprintf('The "%s" tag on service "%s" requires a non-empty "salt" attribute, e.g. { name: \'%s\', salt: \'acme/my-extension@1.0.0\' }.', self::TAG_NAME, $serviceId, self::TAG_NAME));
+                }
+
+                $salts[] = $salt;
+            }
+        }
+
+        $salts = array_unique($salts);
+        sort($salts);
+
+        $cache->replaceArgument(self::SALT_ARGUMENT, implode('|', $salts));
+    }
+}

--- a/src/Supportive/DependencyInjection/ServiceContainerBuilder.php
+++ b/src/Supportive/DependencyInjection/ServiceContainerBuilder.php
@@ -113,6 +113,7 @@ final class ServiceContainerBuilder
     {
         $container->addCompilerPass(new AddConsoleCommandPass());
         $container->addCompilerPass(new RegisterListenersPass());
+        $container->addCompilerPass(new AstCacheVersionSaltsPass());
     }
 
     /**

--- a/tests/Contract/Ast/CustomTokenTest.php
+++ b/tests/Contract/Ast/CustomTokenTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Deptrac\Deptrac\Contract\Ast;
+
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeToken;
+use Deptrac\Deptrac\Contract\Ast\AstMap\CustomToken;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+final class CustomTokenTest extends TestCase
+{
+    public function testCarriesTypePayloadAndDisplayString(): void
+    {
+        $token = new CustomToken(
+            'acme/my-extension.route',
+            ['path' => '/foo', 'methods' => ['GET', 'POST'], 'priority' => 3, 'internal' => false, 'condition' => null],
+            'route:/foo',
+        );
+
+        self::assertSame('acme/my-extension.route', $token->type);
+        self::assertSame('/foo', $token->payload['path']);
+        self::assertSame('route:/foo', $token->toString());
+    }
+
+    public function testEqualsComparesTypeAndPayload(): void
+    {
+        $token = new CustomToken('acme.route', ['path' => '/foo'], 'route:/foo');
+
+        self::assertTrue($token->equals(new CustomToken('acme.route', ['path' => '/foo'], 'route:/foo')));
+        self::assertFalse($token->equals(new CustomToken('acme.command', ['path' => '/foo'], 'route:/foo')));
+        self::assertFalse($token->equals(new CustomToken('acme.route', ['path' => '/bar'], 'route:/foo')));
+        self::assertFalse($token->equals(ClassLikeToken::fromFQCN('App\Foo')));
+    }
+
+    public function testRejectsObjectsInPayload(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new CustomToken('acme.route', ['token' => ClassLikeToken::fromFQCN('App\Foo')], 'route');
+    }
+
+    public function testRejectsObjectsNestedInPayloadArrays(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new CustomToken('acme.route', ['nested' => ['deep' => [ClassLikeToken::fromFQCN('App\Foo')]]], 'route');
+    }
+}

--- a/tests/Core/Ast/Parser/Cache/AstFileReferenceFileCacheTest.php
+++ b/tests/Core/Ast/Parser/Cache/AstFileReferenceFileCacheTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Deptrac\Deptrac\Core\Ast\Parser\Cache;
+
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeReference;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeToken;
+use Deptrac\Deptrac\Contract\Ast\AstMap\CustomToken;
+use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyContext;
+use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyToken;
+use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyType;
+use Deptrac\Deptrac\Contract\Ast\AstMap\FileOccurrence;
+use Deptrac\Deptrac\Contract\Ast\AstMap\FileReference;
+use Deptrac\Deptrac\Contract\Ast\AstMap\TokenInterface;
+use Deptrac\Deptrac\Core\Ast\Parser\Cache\AstFileReferenceFileCache;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Tests\Deptrac\Deptrac\Core\Ast\Parser\Cache\Fixtures\CustomCachedToken;
+
+final class AstFileReferenceFileCacheTest extends TestCase
+{
+    private string $cacheFile;
+
+    protected function setUp(): void
+    {
+        $this->cacheFile = (string) tempnam(sys_get_temp_dir(), 'deptrac_cache_test');
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->cacheFile);
+    }
+
+    public function testCustomTokensSurviveRoundTrip(): void
+    {
+        $token = new CustomToken(
+            'acme/my-extension.method',
+            ['class' => 'App\Fixture', 'method' => 'bar'],
+            'App\Fixture::bar()',
+        );
+
+        $writer = new AstFileReferenceFileCache($this->cacheFile, '1.0.0', 'ext-salt');
+        $writer->set($this->fileReferenceWithToken($token));
+        $writer->write();
+
+        $reader = new AstFileReferenceFileCache($this->cacheFile, '1.0.0', 'ext-salt');
+        $reference = $reader->get(__FILE__);
+
+        self::assertNotNull($reference);
+        $cachedToken = $reference->classLikeReferences[0]->dependencies[0]->token;
+        self::assertInstanceOf(CustomToken::class, $cachedToken);
+        self::assertSame('acme/my-extension.method', $cachedToken->type);
+        self::assertSame(['class' => 'App\Fixture', 'method' => 'bar'], $cachedToken->payload);
+        self::assertSame('App\Fixture::bar()', $cachedToken->toString());
+    }
+
+    public function testEntriesWithExtensionDefinedClassesAreDiscarded(): void
+    {
+        $writer = new AstFileReferenceFileCache($this->cacheFile, '1.0.0');
+        $writer->set($this->fileReferenceWithToken(new CustomCachedToken('custom-token')));
+        $writer->write();
+
+        $reader = new AstFileReferenceFileCache($this->cacheFile, '1.0.0');
+
+        self::assertNull($reader->get(__FILE__));
+    }
+
+    public function testEntriesWithObjectsInCustomTokenPayloadsAreDiscarded(): void
+    {
+        // a CustomToken cannot be constructed with objects in its payload, so
+        // forge one the way a tampered cache file could deliver it
+        $token = (new ReflectionClass(CustomToken::class))->newInstanceWithoutConstructor();
+        (function (): void {
+            /** @var CustomToken $this */
+            $this->type = 'acme.forged';
+            $this->payload = ['occurrence' => new FileOccurrence(__FILE__, 1)];
+            $this->display = 'forged';
+        })->call($token);
+
+        $writer = new AstFileReferenceFileCache($this->cacheFile, '1.0.0');
+        $writer->set($this->fileReferenceWithToken($token));
+        $writer->write();
+
+        $reader = new AstFileReferenceFileCache($this->cacheFile, '1.0.0');
+
+        self::assertNull($reader->get(__FILE__));
+    }
+
+    public function testVersionSaltInvalidatesCache(): void
+    {
+        $writer = new AstFileReferenceFileCache($this->cacheFile, '1.0.0');
+        $writer->set($this->fileReferenceWithToken(new CustomToken('acme.token', [], 'token')));
+        $writer->write();
+
+        $reader = new AstFileReferenceFileCache($this->cacheFile, '1.0.0', 'ext-salt');
+
+        self::assertNull($reader->get(__FILE__));
+    }
+
+    private function fileReferenceWithToken(TokenInterface $token): FileReference
+    {
+        $classReference = new ClassLikeReference(
+            ClassLikeToken::fromFQCN('App\Fixture'),
+            null,
+            [],
+            [
+                new DependencyToken(
+                    $token,
+                    new DependencyContext(new FileOccurrence(__FILE__, 1), DependencyType::USE)
+                ),
+            ],
+        );
+
+        return new FileReference(__FILE__, [$classReference], [], []);
+    }
+}

--- a/tests/Core/Ast/Parser/Cache/Fixtures/CustomCachedToken.php
+++ b/tests/Core/Ast/Parser/Cache/Fixtures/CustomCachedToken.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Deptrac\Deptrac\Core\Ast\Parser\Cache\Fixtures;
+
+use Deptrac\Deptrac\Contract\Ast\AstMap\TokenInterface;
+
+final class CustomCachedToken implements TokenInterface
+{
+    public function __construct(public readonly string $name) {}
+
+    public function toString(): string
+    {
+        return $this->name;
+    }
+
+    public function equals(TokenInterface $token): bool
+    {
+        return $token instanceof self && $token->name === $this->name;
+    }
+}

--- a/tests/Supportive/DependencyInjection/AstCacheVersionSaltsPassTest.php
+++ b/tests/Supportive/DependencyInjection/AstCacheVersionSaltsPassTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Deptrac\Deptrac\Supportive\DependencyInjection;
+
+use Deptrac\Deptrac\Contract\Ast\AstFileReferenceCacheInterface;
+use Deptrac\Deptrac\Core\Ast\Parser\Cache\AstFileReferenceFileCache;
+use Deptrac\Deptrac\Core\Ast\Parser\Cache\AstFileReferenceInMemoryCache;
+use Deptrac\Deptrac\Supportive\DependencyInjection\AstCacheVersionSaltsPass;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
+final class AstCacheVersionSaltsPassTest extends TestCase
+{
+    public function testComposesTaggedSaltsDeduplicatedAndSorted(): void
+    {
+        $container = $this->containerWithFileCache();
+        $container->register('extension_b', stdClass::class)
+            ->addTag(AstCacheVersionSaltsPass::TAG_NAME, ['salt' => 'vendor-b/extension@2.0'])
+        ;
+        $container->register('extension_a', stdClass::class)
+            ->addTag(AstCacheVersionSaltsPass::TAG_NAME, ['salt' => 'vendor-a/extension@1.0'])
+        ;
+        // the same extension may tag several of its services with the same salt
+        $container->register('extension_a_other_service', stdClass::class)
+            ->addTag(AstCacheVersionSaltsPass::TAG_NAME, ['salt' => 'vendor-a/extension@1.0'])
+        ;
+
+        (new AstCacheVersionSaltsPass())->process($container);
+
+        self::assertSame(
+            'vendor-a/extension@1.0|vendor-b/extension@2.0',
+            $container->getDefinition(AstFileReferenceFileCache::class)->getArgument('$cacheVersionSalt'),
+        );
+    }
+
+    public function testLeavesSaltEmptyWithoutTaggedServices(): void
+    {
+        $container = $this->containerWithFileCache();
+
+        (new AstCacheVersionSaltsPass())->process($container);
+
+        self::assertSame('', $container->getDefinition(AstFileReferenceFileCache::class)->getArgument('$cacheVersionSalt'));
+    }
+
+    public function testDoesNothingWithoutRegisteredCache(): void
+    {
+        $container = new ContainerBuilder();
+        $container->register('extension', stdClass::class)
+            ->addTag(AstCacheVersionSaltsPass::TAG_NAME, ['salt' => 'vendor/extension@1.0'])
+        ;
+
+        (new AstCacheVersionSaltsPass())->process($container);
+
+        self::assertFalse($container->has(AstFileReferenceCacheInterface::class));
+    }
+
+    public function testLeavesTheInMemoryCacheAloneWhenCachingIsDisabled(): void
+    {
+        $container = new ContainerBuilder();
+        $container->register(AstFileReferenceInMemoryCache::class, AstFileReferenceInMemoryCache::class);
+        $container->setAlias(AstFileReferenceCacheInterface::class, AstFileReferenceInMemoryCache::class);
+        $container->register('extension', stdClass::class)
+            ->addTag(AstCacheVersionSaltsPass::TAG_NAME, ['salt' => 'vendor/extension@1.0'])
+        ;
+
+        (new AstCacheVersionSaltsPass())->process($container);
+
+        self::assertSame([], $container->getDefinition(AstFileReferenceInMemoryCache::class)->getArguments());
+    }
+
+    public function testRejectsTagsWithoutSaltAttribute(): void
+    {
+        $container = $this->containerWithFileCache();
+        $container->register('extension', stdClass::class)
+            ->addTag(AstCacheVersionSaltsPass::TAG_NAME)
+        ;
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('requires a non-empty "salt" attribute');
+
+        (new AstCacheVersionSaltsPass())->process($container);
+    }
+
+    /**
+     * The cache wiring of cache.php: the concrete file cache with a named salt
+     * argument, reachable through the contract alias.
+     */
+    private function containerWithFileCache(): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $container->register(AstFileReferenceFileCache::class, AstFileReferenceFileCache::class)
+            ->setArguments(['/tmp/cache', '1.0.0', '$cacheVersionSalt' => ''])
+        ;
+        $container->setAlias(AstFileReferenceCacheInterface::class, AstFileReferenceFileCache::class);
+
+        return $container;
+    }
+}


### PR DESCRIPTION
Fixes: #1560

A custom token is introduced and is used as the new data-only `Contract\Ast\AstMap\CustomToken` which the extensions are supposed to use a cache is required. The `CustomToken` is a vendor-namespaced type tag, a payload restricted to scalars, null and arrays thereof, and a display string. The payload restriction is enforced in the constructor and re-checked in `__wakeup()`, so a tampered cache entry is discarded instead of restoring forged state.

Each extension now can contribute its own salt by tagging one of its registered services (typically the extractor recording the cached references) with `{ name: 'ast_cache.version_salt', salt: 'name@version' }`. A compiler pass  deduplicates and sorts the tagged salts and composes them into the cache version, so the result is deterministic, independent of registration order, and end users no longer have to compose anything.

Entries that cannot be restored are now discarded and re-parsed instead of crashing, and the cache version gains an internal schema component so layout changes within a release cycle invalidate existing caches.

Cache entries containing classes outside the allowlist previously blew up with a TypeError while assigning __PHP_Incomplete_Class to a typed property during load, such entries are now discarded and the affected files re-parsed.
