### PR TITLE
feat: add DependencyType::METHOD_CALL

### DIFF
--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -10,6 +10,11 @@
   `TokenResolverInterface` is aliased to. The default resolver's `resolve()`
   now accepts any `AstMapInterface` (previously the concrete `Core\Ast\AstMap`).
 
+### Possible BC impact
+
+- New enum case `DependencyType::METHOD_CALL`. Code `match`ing exhaustively
+  over `DependencyType` without a default arm needs a new arm.
+
 # Upgrade from 1.0.2 to 2.0.0
 
 ### Dropped functionality

--- a/src/Contract/Ast/AstMap/DependencyType.php
+++ b/src/Contract/Ast/AstMap/DependencyType.php
@@ -19,6 +19,7 @@ enum DependencyType: string
     case NEW = 'new';
     case STATIC_PROPERTY = 'static_property';
     case STATIC_METHOD = 'static_method';
+    case METHOD_CALL = 'method_call';
     case INSTANCEOF = 'instanceof';
     case CATCH = 'catch';
     // Class-like property or @var tag annotation

--- a/src/DefaultBehavior/Dependency/ClassDependencyEmitter.php
+++ b/src/DefaultBehavior/Dependency/ClassDependencyEmitter.php
@@ -30,6 +30,12 @@ final class ClassDependencyEmitter implements DependencyEmitterInterface
                 if (DependencyType::UNRESOLVED_FUNCTION_CALL === $dependency->context->dependencyType) {
                     continue;
                 }
+                // intra-class dispatch is finer-grained information than
+                // class-level analysis uses - a class calling its own methods
+                // is not a dependency between two classes
+                if (DependencyType::METHOD_CALL === $dependency->context->dependencyType) {
+                    continue;
+                }
 
                 $dependencyList->addDependency(
                     new Dependency(

--- a/tests/Core/Dependency/Emitter/ClassDependencyEmitterTest.php
+++ b/tests/Core/Dependency/Emitter/ClassDependencyEmitterTest.php
@@ -4,6 +4,15 @@ declare(strict_types=1);
 
 namespace Tests\Deptrac\Deptrac\Core\Dependency\Emitter;
 
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeReference;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeToken;
+use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyContext;
+use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyToken;
+use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyType;
+use Deptrac\Deptrac\Contract\Ast\AstMap\FileOccurrence;
+use Deptrac\Deptrac\Contract\Ast\AstMap\FileReference;
+use Deptrac\Deptrac\Core\Ast\AstMap;
+use Deptrac\Deptrac\Core\Dependency\DependencyList;
 use Deptrac\Deptrac\DefaultBehavior\Dependency\ClassDependencyEmitter;
 use PHPUnit\Framework\TestCase;
 
@@ -41,5 +50,35 @@ final class ClassDependencyEmitterTest extends TestCase
         self::assertContains('Foo\Bar:32 on Foo\SomeClass', $deps);
         self::assertContains('Foo\Bar:36 on Foo\string2', $deps);
         self::assertContains('Foo\Bar:42 on Foo\SomeClass', $deps);
+    }
+
+    public function testDoesNotEmitMethodCallReferences(): void
+    {
+        $classReference = new ClassLikeReference(
+            ClassLikeToken::fromFQCN('Foo\Bar'),
+            null,
+            [],
+            [
+                new DependencyToken(
+                    ClassLikeToken::fromFQCN('Foo\Baz'),
+                    new DependencyContext(new FileOccurrence('/foo.php', 3), DependencyType::NEW)
+                ),
+                new DependencyToken(
+                    ClassLikeToken::fromFQCN('self::helper()'),
+                    new DependencyContext(new FileOccurrence('/foo.php', 4), DependencyType::METHOD_CALL)
+                ),
+            ],
+        );
+        $astMap = new AstMap([new FileReference('/foo.php', [$classReference], [], [])]);
+        $result = new DependencyList();
+
+        (new ClassDependencyEmitter())->applyDependencies($astMap, $result);
+
+        $deps = array_map(
+            static fn ($dependency) => $dependency->getDependent()->toString(),
+            $result->getDependenciesAndInheritDependencies()
+        );
+
+        self::assertSame(['Foo\Baz'], $deps);
     }
 }


### PR DESCRIPTION
Fixes: #1567

The new dependency type lets extensions (and future core extractors) mark references that originate from intra-class method calls. The class-level dependency emitter ignores them: a class calling its own methods is not a dependency between two classes.
