### PR TITLE
feat: record class method spans in class-like references

### DIFF
--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -9,6 +9,15 @@
   `Core\Dependency\DelegatingTokenResolver`, which is what
   `TokenResolverInterface` is aliased to. The default resolver's `resolve()`
   now accepts any `AstMapInterface` (previously the concrete `Core\Ast\AstMap`).
+- Class-like references now carry `ClassMethodSpan` metadata (method name,
+  declaration lines, visibility, static flag) in
+  `ClassLikeReference::$methodSpans`; its constructor gained an optional
+  `$methodSpans` parameter as its last argument.
+
+### Possible BC impact
+
+- The AST cache layout version changed; existing caches are invalidated once
+  and rebuilt on the next run.
 
 # Upgrade from 1.0.2 to 2.0.0
 

--- a/src/Contract/Ast/AstMap/ClassLikeReference.php
+++ b/src/Contract/Ast/AstMap/ClassLikeReference.php
@@ -15,6 +15,7 @@ final class ClassLikeReference extends TaggedTokenReference
      * @param AstInherit[] $inherits
      * @param DependencyToken[] $dependencies
      * @param array<string,list<string>> $tags
+     * @param ClassMethodSpan[] $methodSpans
      */
     public function __construct(
         private readonly ClassLikeToken $classLikeName,
@@ -23,6 +24,7 @@ final class ClassLikeReference extends TaggedTokenReference
         public readonly array $dependencies = [],
         public readonly array $tags = [],
         private readonly ?FileReference $fileReference = null,
+        public readonly array $methodSpans = [],
     ) {
         parent::__construct($tags);
         $this->type = $classLikeType ?? ClassLikeType::TYPE_CLASSLIKE;
@@ -36,7 +38,8 @@ final class ClassLikeReference extends TaggedTokenReference
             $this->inherits,
             $this->dependencies,
             $this->tags,
-            $astFileReference
+            $astFileReference,
+            $this->methodSpans
         );
     }
 

--- a/src/Contract/Ast/AstMap/ClassMethodSpan.php
+++ b/src/Contract/Ast/AstMap/ClassMethodSpan.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deptrac\Deptrac\Contract\Ast\AstMap;
+
+/**
+ * Describes where a method is declared within a class-like reference.
+ *
+ * The span covers the whole method declaration including its attribute
+ * groups, so any dependency recorded on the class-like reference whose line
+ * falls inside the span originates from that method.
+ *
+ * @psalm-immutable
+ */
+final class ClassMethodSpan
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly int $startLine,
+        public readonly int $endLine,
+        public readonly ClassMethodVisibility $visibility,
+        public readonly bool $isStatic,
+    ) {}
+}

--- a/src/Contract/Ast/AstMap/ClassMethodVisibility.php
+++ b/src/Contract/Ast/AstMap/ClassMethodVisibility.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deptrac\Deptrac\Contract\Ast\AstMap;
+
+enum ClassMethodVisibility: string
+{
+    case PUBLIC = 'public';
+    case PROTECTED = 'protected';
+    case PRIVATE = 'private';
+}

--- a/src/Core/Ast/Parser/Cache/AstFileReferenceFileCache.php
+++ b/src/Core/Ast/Parser/Cache/AstFileReferenceFileCache.php
@@ -8,6 +8,8 @@ use Deptrac\Deptrac\Contract\Ast\AstMap\AstInherit;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeReference;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeToken;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeType;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodSpan;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodVisibility;
 use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyContext;
 use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyToken;
 use Deptrac\Deptrac\Contract\Ast\AstMap\DependencyType;
@@ -37,13 +39,25 @@ use function unserialize;
 
 class AstFileReferenceFileCache implements AstFileReferenceDeferredCacheInterface
 {
+    /**
+     * Internal cache layout version, independent of the deptrac release
+     * version. Bump whenever the serialized shape of the cached references
+     * changes within a release cycle.
+     */
+    private const SCHEMA_VERSION = '2';
+
     /** @var array<string, array{hash: string, reference: FileReference}> */
     private array $cache = [];
     private bool $loaded = false;
     /** @var array<string, bool> */
     private array $parsedFiles = [];
 
-    public function __construct(private readonly string $cacheFile, private readonly string $cacheVersion) {}
+    private readonly string $cacheVersion;
+
+    public function __construct(private readonly string $cacheFile, string $cacheVersion)
+    {
+        $this->cacheVersion = $cacheVersion.'@'.self::SCHEMA_VERSION;
+    }
 
     public function get(string $filepath): ?FileReference
     {
@@ -119,6 +133,8 @@ class AstFileReferenceFileCache implements AstFileReferenceDeferredCacheInterfac
                             FileToken::class,
                             ClassLikeToken::class,
                             ClassLikeType::class,
+                            ClassMethodSpan::class,
+                            ClassMethodVisibility::class,
                             FunctionToken::class,
                             SuperGlobalToken::class,
                             FileOccurrence::class,

--- a/src/DefaultBehavior/Ast/Parser/Helpers/ClassLikeReferenceBuilder.php
+++ b/src/DefaultBehavior/Ast/Parser/Helpers/ClassLikeReferenceBuilder.php
@@ -7,9 +7,13 @@ namespace Deptrac\Deptrac\DefaultBehavior\Ast\Parser\Helpers;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeReference;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeToken;
 use Deptrac\Deptrac\Contract\Ast\AstMap\ClassLikeType;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodSpan;
 
 final class ClassLikeReferenceBuilder extends ReferenceBuilder
 {
+    /** @var ClassMethodSpan[] */
+    private array $methodSpans = [];
+
     /**
      * @param list<string> $tokenTemplates
      * @param array<string,list<string>> $tags
@@ -60,6 +64,13 @@ final class ClassLikeReferenceBuilder extends ReferenceBuilder
         return new self($classTemplates, $filepath, ClassLikeToken::fromFQCN($classLikeName), ClassLikeType::TYPE_INTERFACE, $tags);
     }
 
+    public function methodSpan(ClassMethodSpan $methodSpan): self
+    {
+        $this->methodSpans[] = $methodSpan;
+
+        return $this;
+    }
+
     /** @internal */
     public function build(): ClassLikeReference
     {
@@ -68,7 +79,9 @@ final class ClassLikeReferenceBuilder extends ReferenceBuilder
             $this->classLikeType,
             $this->inherits,
             $this->dependencies,
-            $this->tags
+            $this->tags,
+            null,
+            $this->methodSpans
         );
     }
 }

--- a/src/DefaultBehavior/Ast/Parser/Helpers/NikicFileReferenceVisitor.php
+++ b/src/DefaultBehavior/Ast/Parser/Helpers/NikicFileReferenceVisitor.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Deptrac\Deptrac\DefaultBehavior\Ast\Parser\Helpers;
 
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodSpan;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodVisibility;
 use Deptrac\Deptrac\Contract\Ast\NikicReferenceExtractorInterface;
 use Deptrac\Deptrac\Contract\Ast\TypeScope;
 use Deptrac\Deptrac\DefaultBehavior\Ast\DocParsingHelper;
@@ -11,6 +13,7 @@ use PhpParser\Node;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\GroupUse;
 use PhpParser\Node\Stmt\Interface_;
 use PhpParser\Node\Stmt\Namespace_;
@@ -33,6 +36,8 @@ class NikicFileReferenceVisitor extends NodeVisitorAbstract
     private readonly PhpDocParser $docParser;
 
     private ReferenceBuilder $currentReference;
+
+    private int $anonymousClassDepth = 0;
 
     /**
      * @param NikicReferenceExtractorInterface<Node> ...$dependencyResolvers
@@ -82,6 +87,7 @@ class NikicFileReferenceVisitor extends NodeVisitorAbstract
         match (true) {
             $node instanceof Namespace_ => $this->currentTypeScope = new TypeScope($node->name ? $node->name->toCodeString() : ''),
             $node instanceof ClassLike, $node instanceof Node\Stmt\Function_ => $this->enterReferenceChangingNode($node),
+            $node instanceof ClassMethod => $this->enterClassMethod($node),
             $node instanceof Node\FunctionLike => $this->enterFunctionLike($node),
             $node instanceof Use_ && Use_::TYPE_NORMAL === $node->type => $this->enterUse($node),
             $node instanceof GroupUse => $this->enterGroupUse($node),
@@ -105,6 +111,10 @@ class NikicFileReferenceVisitor extends NodeVisitorAbstract
             }
         }
 
+        if ($node instanceof ClassLike && null === $this->getReferenceName($node)) {
+            --$this->anonymousClassDepth;
+        }
+
         $this->currentReference = match (true) {
             $node instanceof Node\Stmt\Function_ => $this->fileReferenceBuilder,
             $node instanceof ClassLike && null !== $this->getReferenceName($node) => $this->fileReferenceBuilder,
@@ -117,6 +127,9 @@ class NikicFileReferenceVisitor extends NodeVisitorAbstract
     private function enterReferenceChangingNode(Node\Stmt\Function_|ClassLike $node): void
     {
         $name = $this->getReferenceName($node);
+        if (null === $name && $node instanceof ClassLike) {
+            ++$this->anonymousClassDepth;
+        }
         if (null !== $name) {
             $tags = $this->getTags($node);
             $templateTypes = $this->templateLikesFromDocs($node);
@@ -142,6 +155,25 @@ class NikicFileReferenceVisitor extends NodeVisitorAbstract
         }
 
         return null;
+    }
+
+    private function enterClassMethod(ClassMethod $node): void
+    {
+        if (0 === $this->anonymousClassDepth && $this->currentReference instanceof ClassLikeReferenceBuilder) {
+            $this->currentReference->methodSpan(new ClassMethodSpan(
+                $node->name->toString(),
+                $node->getStartLine(),
+                $node->getEndLine(),
+                match (true) {
+                    $node->isPrivate() => ClassMethodVisibility::PRIVATE,
+                    $node->isProtected() => ClassMethodVisibility::PROTECTED,
+                    default => ClassMethodVisibility::PUBLIC,
+                },
+                $node->isStatic(),
+            ));
+        }
+
+        $this->enterFunctionLike($node);
     }
 
     private function enterFunctionLike(Node\FunctionLike $node): void

--- a/src/DefaultBehavior/Ast/Parser/Helpers/PhpStanFileReferenceVisitor.php
+++ b/src/DefaultBehavior/Ast/Parser/Helpers/PhpStanFileReferenceVisitor.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Deptrac\Deptrac\DefaultBehavior\Ast\Parser\Helpers;
 
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodSpan;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodVisibility;
 use Deptrac\Deptrac\Contract\Ast\PHPStanReferenceExtractorInterface;
 use Deptrac\Deptrac\DefaultBehavior\Ast\DocParsingHelper;
 use PhpParser\Node;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Interface_;
 use PhpParser\Node\Stmt\Trait_;
 use PhpParser\NodeVisitorAbstract;
@@ -27,6 +30,8 @@ class PhpStanFileReferenceVisitor extends NodeVisitorAbstract
     private readonly array $dependencyResolvers;
 
     private ReferenceBuilder $currentReference;
+
+    private int $anonymousClassDepth = 0;
 
     private MutatingScope $scope;
 
@@ -55,6 +60,7 @@ class PhpStanFileReferenceVisitor extends NodeVisitorAbstract
         match (true) {
             $node instanceof Node\Stmt\Function_ => $this->enterFunction($node),
             $node instanceof ClassLike => $this->enterClassLike($node),
+            $node instanceof ClassMethod => $this->enterClassMethod($node),
             default => null,
         };
 
@@ -69,6 +75,10 @@ class PhpStanFileReferenceVisitor extends NodeVisitorAbstract
             }
         }
 
+        if ($node instanceof ClassLike && null === $this->getReferenceName($node)) {
+            --$this->anonymousClassDepth;
+        }
+
         $this->currentReference = match (true) {
             $node instanceof Node\Stmt\Function_ => $this->fileReferenceBuilder,
             $node instanceof ClassLike && null !== $this->getReferenceName($node) => $this->fileReferenceBuilder,
@@ -78,9 +88,31 @@ class PhpStanFileReferenceVisitor extends NodeVisitorAbstract
         return null;
     }
 
+    private function enterClassMethod(ClassMethod $node): void
+    {
+        if (0 !== $this->anonymousClassDepth || !$this->currentReference instanceof ClassLikeReferenceBuilder) {
+            return;
+        }
+
+        $this->currentReference->methodSpan(new ClassMethodSpan(
+            $node->name->toString(),
+            $node->getStartLine(),
+            $node->getEndLine(),
+            match (true) {
+                $node->isPrivate() => ClassMethodVisibility::PRIVATE,
+                $node->isProtected() => ClassMethodVisibility::PROTECTED,
+                default => ClassMethodVisibility::PUBLIC,
+            },
+            $node->isStatic(),
+        ));
+    }
+
     private function enterClassLike(ClassLike $node): void
     {
         $name = $this->getReferenceName($node);
+        if (null === $name) {
+            ++$this->anonymousClassDepth;
+        }
         if (null !== $name) {
             if (!$node instanceof Trait_) {
                 $context = ScopeContext::create($this->file)

--- a/tests/Core/Ast/Parser/ClassMethodSpanTest.php
+++ b/tests/Core/Ast/Parser/ClassMethodSpanTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Deptrac\Deptrac\Core\Ast\Parser;
+
+use Closure;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodSpan;
+use Deptrac\Deptrac\Contract\Ast\AstMap\ClassMethodVisibility;
+use Deptrac\Deptrac\Core\Ast\Parser\Cache\AstFileReferenceInMemoryCache;
+use Deptrac\Deptrac\DefaultBehavior\Ast\Parser\Helpers\PhpStanContainerDecorator;
+use Deptrac\Deptrac\DefaultBehavior\Ast\Parser\NikicPhpParser;
+use Deptrac\Deptrac\DefaultBehavior\Ast\Parser\PhpStanParser;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ClassMethodSpanTest extends TestCase
+{
+    #[DataProvider('createParser')]
+    public function testMethodSpansAreRecorded(Closure $parserBuilder): void
+    {
+        $filePath = __DIR__.'/Fixtures/ClassMethodSpans.php';
+        $parser = $parserBuilder($filePath);
+        $astFileReference = $parser->parseFile($filePath);
+
+        $classReferences = [];
+        foreach ($astFileReference->classLikeReferences as $classReference) {
+            $classReferences[$classReference->getToken()->toString()] = $classReference;
+        }
+
+        $namespace = 'Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures';
+
+        self::assertSame([], $classReferences[$namespace.'\SpanFixtureAttribute']->methodSpans);
+
+        $spans = $classReferences[$namespace.'\ClassMethodSpans']->methodSpans;
+        self::assertCount(3, $spans, 'methods of anonymous classes must not be recorded');
+
+        $this->assertSpan($spans[0], 'plain', 18, 23, ClassMethodVisibility::PUBLIC, false);
+        $this->assertSpan($spans[1], 'withAttribute', 25, 29, ClassMethodVisibility::PROTECTED, false);
+        $this->assertSpan($spans[2], 'helper', 31, 38, ClassMethodVisibility::PRIVATE, true);
+
+        $interfaceSpans = $classReferences[$namespace.'\ClassMethodSpansInterface']->methodSpans;
+        self::assertCount(1, $interfaceSpans);
+        $this->assertSpan($interfaceSpans[0], 'signatureOnly', 43, 43, ClassMethodVisibility::PUBLIC, false);
+
+        $traitSpans = $classReferences[$namespace.'\ClassMethodSpansTrait']->methodSpans;
+        self::assertCount(1, $traitSpans);
+        $this->assertSpan($traitSpans[0], 'fromTrait', 48, 50, ClassMethodVisibility::PUBLIC, false);
+
+        $enumSpans = $classReferences[$namespace.'\ClassMethodSpansEnum']->methodSpans;
+        self::assertCount(1, $enumSpans);
+        $this->assertSpan($enumSpans[0], 'label', 57, 60, ClassMethodVisibility::PUBLIC, false);
+    }
+
+    private function assertSpan(
+        ClassMethodSpan $span,
+        string $name,
+        int $startLine,
+        int $endLine,
+        ClassMethodVisibility $visibility,
+        bool $isStatic,
+    ): void {
+        self::assertSame($name, $span->name);
+        self::assertSame($startLine, $span->startLine, sprintf('start line of %s()', $name));
+        self::assertSame($endLine, $span->endLine, sprintf('end line of %s()', $name));
+        self::assertSame($visibility, $span->visibility, sprintf('visibility of %s()', $name));
+        self::assertSame($isStatic, $span->isStatic, sprintf('staticness of %s()', $name));
+    }
+
+    /**
+     * @return array<string, list<Closure>>
+     */
+    public static function createParser(): array
+    {
+        return [
+            'Nikic Parser' => [self::createNikicParser(...)],
+            'PHPStan Parser' => [self::createPhpStanParser(...)],
+        ];
+    }
+
+    public static function createNikicParser(string $filePath): NikicPhpParser
+    {
+        return new NikicPhpParser(
+            (new ParserFactory())->createForNewestSupportedVersion(),
+            new AstFileReferenceInMemoryCache(),
+            []
+        );
+    }
+
+    public static function createPhpStanParser(string $filePath): PhpStanParser
+    {
+        $phpStanContainer = new PhpStanContainerDecorator(__DIR__, __DIR__, [$filePath]);
+
+        return new PhpStanParser($phpStanContainer, new AstFileReferenceInMemoryCache(), []);
+    }
+}

--- a/tests/Core/Ast/Parser/Fixtures/ClassMethodSpans.php
+++ b/tests/Core/Ast/Parser/Fixtures/ClassMethodSpans.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Deptrac\Deptrac\Core\Ast\Parser\Fixtures;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class SpanFixtureAttribute
+{
+}
+
+class ClassMethodSpans
+{
+    private const UNUSED = true;
+
+    public function plain(): void
+    {
+        $fn = static function (): void {
+        };
+        $fn();
+    }
+
+    #[SpanFixtureAttribute]
+    protected function withAttribute(): iterable
+    {
+        yield from [];
+    }
+
+    private static function helper(): object
+    {
+        return new class {
+            public function anonymousMethod(): void
+            {
+            }
+        };
+    }
+}
+
+interface ClassMethodSpansInterface
+{
+    public function signatureOnly(): void;
+}
+
+trait ClassMethodSpansTrait
+{
+    public function fromTrait(): void
+    {
+    }
+}
+
+enum ClassMethodSpansEnum
+{
+    case A;
+
+    public function label(): string
+    {
+        return 'a';
+    }
+}


### PR DESCRIPTION
Fixes: #1564

Class-like references now carry `ClassMethodSpan` metadata (method name, declaration lines, visibility, static flag) in `ClassLikeReference::$methodSpans`, recorded by both the Nikic and the PHPStan visitor. This gives extensions enough information to attribute dependencies to individual methods (e.g. method-granular layer analysis).

The spans are serialized into the AST cache with the references, so the two value objects join the `unserialize()` allowlist and the cache version gains an internal schema component: caches written before this change (whose entries lack the new property) are invalidated and rebuilt instead of failing on an uninitialized typed property.

_Note: the cache version is included in this pull request to prevent cache errors in case the other pull request #1561 is not merged._